### PR TITLE
[READY FOR REVIEW] Bump spartan-ecdsa to v2.1.2

### DIFF
--- a/packages/circuits/package.json
+++ b/packages/circuits/package.json
@@ -14,7 +14,7 @@
   },
   "devDependencies": {
     "@ethereumjs/util": "^8.0.5",
-    "@personaelabs/spartan-ecdsa": "^2.1.0",
+    "@personaelabs/spartan-ecdsa": "^2.1.2",
     "@wagmi/core": "^0.10.8",
     "circom_tester": "^0.0.19",
     "ethers": "5",

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -19,7 +19,7 @@
     "@ethereumjs/util": "^8.0.5",
     "@headlessui/react": "^1.7.14",
     "@personaelabs/nymjs": "*",
-    "@personaelabs/spartan-ecdsa": "^2.1.0",
+    "@personaelabs/spartan-ecdsa": "^2.1.2",
     "@prisma/client": "4.5.0",
     "@rainbow-me/rainbowkit": "^0.7.4",
     "@tanstack/react-query": "^4.29.5",

--- a/packages/merkle_tree/package.json
+++ b/packages/merkle_tree/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@ethereumjs/tx": "^4.1.1",
     "@ethereumjs/util": "^8.0.5",
-    "@personaelabs/spartan-ecdsa": "^2.1.0",
+    "@personaelabs/spartan-ecdsa": "^2.1.2",
     "@prisma/client": "4.5.0",
     "alchemy-sdk": "^2.6.1",
     "async-lock": "1.4.0",

--- a/packages/nymjs/package.json
+++ b/packages/nymjs/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "@ethereumjs/util": "^8.0.5",
-    "@personaelabs/spartan-ecdsa": "^2.1.0",
+    "@personaelabs/spartan-ecdsa": "^2.1.2",
     "circomlibjs": "^0.1.7",
     "ethers": "^5",
     "snarkjs": "0.5.0"

--- a/packages/test_data/package.json
+++ b/packages/test_data/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "@ethereumjs/util": "^8.0.5",
     "@personaelabs/nymjs": "*",
-    "@personaelabs/spartan-ecdsa": "^2.1.0",
+    "@personaelabs/spartan-ecdsa": "^2.1.2",
     "@prisma/client": "4.5.0",
     "prisma": "4.5.0",
     "dotenv": "^16.0.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,8 +42,8 @@ importers:
         specifier: ^8.0.5
         version: 8.0.5
       '@personaelabs/spartan-ecdsa':
-        specifier: ^2.1.0
-        version: 2.1.0
+        specifier: ^2.1.2
+        version: 2.1.2
       '@wagmi/core':
         specifier: ^0.10.8
         version: 0.10.8(@types/node@18.15.3)(ethers@5.7.2)(react@18.2.0)(typescript@5.0.4)
@@ -75,8 +75,8 @@ importers:
         specifier: '*'
         version: link:../nymjs
       '@personaelabs/spartan-ecdsa':
-        specifier: ^2.1.0
-        version: 2.1.0
+        specifier: ^2.1.2
+        version: 2.1.2
       '@prisma/client':
         specifier: 4.5.0
         version: 4.5.0(prisma@4.5.0)
@@ -169,8 +169,8 @@ importers:
         specifier: ^8.0.5
         version: 8.0.5
       '@personaelabs/spartan-ecdsa':
-        specifier: ^2.1.0
-        version: 2.1.0
+        specifier: ^2.1.2
+        version: 2.1.2
       '@prisma/client':
         specifier: 4.5.0
         version: 4.5.0(prisma@4.5.0)
@@ -248,8 +248,8 @@ importers:
         specifier: ^8.0.5
         version: 8.0.5
       '@personaelabs/spartan-ecdsa':
-        specifier: ^2.1.0
-        version: 2.1.0
+        specifier: ^2.1.2
+        version: 2.1.2
       circomlibjs:
         specifier: ^0.1.7
         version: 0.1.7
@@ -333,8 +333,8 @@ importers:
         specifier: '*'
         version: link:../nymjs
       '@personaelabs/spartan-ecdsa':
-        specifier: ^2.1.0
-        version: 2.1.0
+        specifier: ^2.1.2
+        version: 2.1.2
       '@prisma/client':
         specifier: 4.5.0
         version: 4.5.0(prisma@4.5.0)
@@ -469,7 +469,7 @@ packages:
       '@babel/traverse': 7.21.4(supports-color@5.5.0)
       '@babel/types': 7.21.4
       convert-source-map: 1.9.0
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@5.5.0)
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.0
@@ -552,7 +552,7 @@ packages:
       '@babel/core': 7.21.4
       '@babel/helper-compilation-targets': 7.21.4(@babel/core@7.21.4)
       '@babel/helper-plugin-utils': 7.20.2
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@5.5.0)
       lodash.debounce: 4.0.8
       resolve: 1.22.2
       semver: 6.3.0
@@ -2120,7 +2120,7 @@ packages:
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dependencies:
       ajv: 6.12.6
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@5.5.0)
       espree: 9.5.1
       globals: 13.20.0
       ignore: 5.2.4
@@ -3526,7 +3526,7 @@ packages:
     engines: {node: '>=10.10.0'}
     dependencies:
       '@humanwhocodes/object-schema': 1.2.1
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@5.5.0)
       minimatch: 3.1.2
     transitivePeerDependencies:
       - supports-color
@@ -3898,7 +3898,7 @@ packages:
     engines: {node: '>=14.0.0'}
     dependencies:
       '@types/debug': 4.1.7
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@5.5.0)
       semver: 7.5.0
       superstruct: 1.0.3
     transitivePeerDependencies:
@@ -4313,6 +4313,15 @@ packages:
 
   /@personaelabs/spartan-ecdsa@2.1.0:
     resolution: {integrity: sha512-VOHv9wlFZbtapXikfjtXXwwGWTaULqdzgMbi1jCVwD7peAUlo9qMtcLZrS8fGmWC8EwiiNH/IpPZxQ533OYLlA==}
+    dependencies:
+      '@ethereumjs/util': 8.0.5
+      '@zk-kit/incremental-merkle-tree': 1.0.0
+      elliptic: 6.5.4
+      snarkjs: 0.5.0
+    dev: false
+
+  /@personaelabs/spartan-ecdsa@2.1.2:
+    resolution: {integrity: sha512-HAJIytU8n74u+sZlls4zymeQACMCgRBd6xXFnKdiCxQ1P+E+BL3/RSdi4+B8rVMvPMRb46QOK4SM1g08WE8GRw==}
     dependencies:
       '@ethereumjs/util': 8.0.5
       '@zk-kit/incremental-merkle-tree': 1.0.0
@@ -5433,7 +5442,7 @@ packages:
       '@typescript-eslint/scope-manager': 5.55.0
       '@typescript-eslint/type-utils': 5.55.0(eslint@8.38.0)(typescript@5.0.2)
       '@typescript-eslint/utils': 5.55.0(eslint@8.38.0)(typescript@5.0.2)
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@5.5.0)
       eslint: 8.38.0
       grapheme-splitter: 1.0.4
       ignore: 5.2.4
@@ -5458,7 +5467,7 @@ packages:
       '@typescript-eslint/scope-manager': 5.55.0
       '@typescript-eslint/types': 5.55.0
       '@typescript-eslint/typescript-estree': 5.55.0(typescript@4.9.5)
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@5.5.0)
       eslint: 8.35.0
       typescript: 4.9.5
     transitivePeerDependencies:
@@ -5478,7 +5487,7 @@ packages:
       '@typescript-eslint/scope-manager': 5.55.0
       '@typescript-eslint/types': 5.55.0
       '@typescript-eslint/typescript-estree': 5.55.0(typescript@5.0.2)
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@5.5.0)
       eslint: 8.38.0
       typescript: 5.0.2
     transitivePeerDependencies:
@@ -5504,7 +5513,7 @@ packages:
     dependencies:
       '@typescript-eslint/typescript-estree': 5.55.0(typescript@5.0.2)
       '@typescript-eslint/utils': 5.55.0(eslint@8.38.0)(typescript@5.0.2)
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@5.5.0)
       eslint: 8.38.0
       tsutils: 3.21.0(typescript@5.0.2)
       typescript: 5.0.2
@@ -5527,7 +5536,7 @@ packages:
     dependencies:
       '@typescript-eslint/types': 5.55.0
       '@typescript-eslint/visitor-keys': 5.55.0
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@5.5.0)
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.5.0
@@ -5548,7 +5557,7 @@ packages:
     dependencies:
       '@typescript-eslint/types': 5.55.0
       '@typescript-eslint/visitor-keys': 5.55.0
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@5.5.0)
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.5.0
@@ -6445,7 +6454,7 @@ packages:
     resolution: {integrity: sha512-7Epl1Blf4Sy37j4v9f9FjICCh4+KAQOyXgHEwlyBiAQLbhKdq/i2QQU3amQalS/wPhdPzDXPL5DMR5bkn+YeWg==}
     engines: {node: '>= 8.0.0'}
     dependencies:
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@5.5.0)
       depd: 2.0.0
       humanize-ms: 1.2.1
     transitivePeerDependencies:
@@ -8122,6 +8131,7 @@ packages:
     dependencies:
       ms: 2.1.2
       supports-color: 8.1.1
+    dev: true
 
   /decamelize-keys@1.1.1:
     resolution: {integrity: sha512-WiPxgEirIV0/eIOMcnFBA3/IJZAZqKnwAwWyvvdi4lsr1WCN22nhdf/3db3DoZcUjTV2SqfzIwNyp6y2xs3nmg==}
@@ -8678,7 +8688,7 @@ packages:
       eslint: '*'
       eslint-plugin-import: '*'
     dependencies:
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@5.5.0)
       enhanced-resolve: 5.13.0
       eslint: 8.35.0
       eslint-module-utils: 2.8.0(@typescript-eslint/parser@5.55.0)(eslint-import-resolver-node@0.3.7)(eslint-import-resolver-typescript@3.5.5)(eslint@8.35.0)
@@ -8869,7 +8879,7 @@ packages:
       ajv: 6.12.6
       chalk: 4.1.2
       cross-spawn: 7.0.3
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@5.5.0)
       doctrine: 3.0.0
       escape-string-regexp: 4.0.0
       eslint-scope: 7.2.0
@@ -8920,7 +8930,7 @@ packages:
       ajv: 6.12.6
       chalk: 4.1.2
       cross-spawn: 7.0.3
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@5.5.0)
       doctrine: 3.0.0
       escape-string-regexp: 4.0.0
       eslint-scope: 7.2.0
@@ -10660,7 +10670,7 @@ packages:
     resolution: {integrity: sha512-n3s8EwkdFIJCG3BPKBYvskgXGoy88ARzvegkitk60NxRdwltLOTaH7CUiMRXvwYorl0Q712iEjcWB+fK/MrWVw==}
     engines: {node: '>=10'}
     dependencies:
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@5.5.0)
       istanbul-lib-coverage: 3.2.0
       source-map: 0.6.1
     transitivePeerDependencies:
@@ -11529,7 +11539,7 @@ packages:
       chalk: 5.2.0
       cli-truncate: 3.1.0
       commander: 10.0.1
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@5.5.0)
       execa: 7.1.1
       lilconfig: 2.1.0
       listr2: 5.0.8
@@ -15032,6 +15042,7 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       has-flag: 4.0.0
+    dev: true
 
   /supports-preserve-symlinks-flag@1.0.0:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}


### PR DESCRIPTION
[spartan-ecdsa v.2.1.2](https://github.com/personaelabs/spartan-ecdsa/releases/tag/v2.1.2) makes Poseidon hashing considerably faster (by lazy loading the Poseidon constants to global memory instead of loading them every time the hash function is called).

Confirmed that all tests pass.

Feel free to merge on approval!