### PR TITLE
[WIP] Add IaC for Render (Staging env setup)

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -18,7 +18,7 @@ services:
 
 databases:
   - name: nouns250
-  - databaseName: nym
-  - region: oregon
-  - plan: starter
-  - postgresMajorVersion: 15
+    databaseName: nym
+    region: oregon
+    plan: starter
+    postgresMajorVersion: 15

--- a/render.yaml
+++ b/render.yaml
@@ -11,10 +11,10 @@ services:
     buildCommand: pnpm i && pnpm build
     startCommand: pnpm run writeTree
     envVars:
-      - key: DB_URL
-      - fromDatabase:
-        - name: nouns250
-        - property: connectionString
+      - key: DATABASE_URL
+        fromDatabase:
+          name: nouns250
+          property: connectionString
 
 databases:
   - name: nouns250

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,24 @@
+previewsEnabled: true
+services:
+  - type: cron
+    name: nouns250-merkle-cron
+    plan: standard
+    previewPlan: standard
+    env: node
+    region: oregon
+    rootDir: packages/merkle_tree
+    schedule: "0 * * * *"
+    buildCommand: pnpm i && pnpm build
+    startCommand: pnpm run writeTree
+    envVars:
+      - key: DB_URL
+      - fromDatabase:
+        - name: nouns250
+        - property: connectionString
+
+databases:
+  - name: nouns250
+  - databaseName: nym
+  - region: oregon
+  - plan: starter
+  - postgresMajorVersion: 15


### PR DESCRIPTION
## This PR
Setup [Infrastructure as Code](https://render.com/docs/infrastructure-as-code) for the merkle-tree service and the database in Render.

The main motivation is to use [Preview Environments](https://render.com/docs/preview-environments), which deploys a new set of services (including the database) defined in render.yaml for every PR. With this, we can have a “staging” environment for the merkle tree service.

The existing services of prop150 [won’t be deleted](https://render.com/docs/infrastructure-as-code#no-automatic-deletions). And we probably don’t want to add their information to render.yaml since that could unexpectedly update the configuration of the services.

Once this PR is merged, we can apply render.yaml from the `Blueprints` tab in the Render dashboard.

I tested the render.yaml file in my personal account, and confirmed that it works.

## RFC
Any notable learnings re the merkle-tree/database CI/CD from prop150 that I should know?

If all looks good, pls merge! (Once merged I'll handle applying render.yaml)
