### PR TITLE
[READY FOR REVIEW] Only copy .env.example to .env in development environments

### DIFF
--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -4,10 +4,9 @@
   "private": true,
   "scripts": {
     "build": "next build",
-    "dev": "next dev",
+    "dev": "cp -n .env.example .env || true && next dev",
     "lint": "next lint",
     "format": "prettier . --write .",
-    "prepare": "cp -n .env.example .env || true",
     "start": "next start"
   },
   "dependencies": {

--- a/packages/test_data/package.json
+++ b/packages/test_data/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "populate": "ts-node ./scripts/populateTestData.ts",
-    "prepare": "cp -n .env.example .env || true"
+    "prepare": "[ -z $DATABASE_URL ] && cp -n .env.example .env || true"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
## Summary
Update pnpm commands to only set `DATABASE_URL` to the local url in development environments.

## Some details
In test_data/, we set `.env` to `.example.env` only if `DATABASE_URL` is not defined already. (In Render, `DATABASE_URL` is defined during build).
For frontend/, we copy `.env.example` to `.env` only when `pnpm run dev` is called. The reason for the difference in approaches between frontend/ and test_data/ is: for Vercel previews, we need to manually copy-paste the `DATABASE_URL` so `DATABASE_URL` is not set during preview builds. (i.e. cannot rely on the availability of `DATABASE_URL` for preview builds)
 