### PR TITLE
Nym Selection / Pseudo Posting

### DIFF
--- a/packages/frontend/src/components/MainButton.tsx
+++ b/packages/frontend/src/components/MainButton.tsx
@@ -5,13 +5,18 @@ export const MainButton = (props: {
   message: string;
   loading: boolean;
   handler: () => void;
+  disabled?: boolean;
 }) => {
-  const { color, message, loading, handler } = props;
+  const { color, message, loading, handler, disabled } = props;
 
   return (
     <button
-      className="font-bold text-white px-4 py-2.5 rounded-xl hover:scale-105 active:scale-100 transition-all"
-      style={{ backgroundColor: color }}
+      className="font-bold text-white px-4 py-2.5 rounded-xl hover:scale-105 active:scale-100 transition-all pointer-cursor"
+      style={{
+        backgroundColor: color,
+        opacity: disabled ? 0.5 : 1,
+        pointerEvents: disabled ? 'none' : 'all',
+      }}
       onClick={handler}
     >
       {loading ? <Spinner /> : <p>{message}</p>}

--- a/packages/frontend/src/components/UpvoteIcon.tsx
+++ b/packages/frontend/src/components/UpvoteIcon.tsx
@@ -16,17 +16,10 @@ export const UpvoteIcon = (props: UpvoteIconProps) => {
     submitUpvote(postId, signTypedDataAsync);
   };
 
-  const outerStyle = {
-    color: '#D0D5DD',
-    ':hover': {
-      color: '#0E76FD',
-    },
-  };
-
   return (
     <div onClick={upvoteHandler} className="flex gap-1 justify-center items-center cursor-pointer">
-      <span className="fa-layers fa-fw">
-        <FontAwesomeIcon icon={faSquare} style={outerStyle} />
+      <span className="fa-layers fa-fw hoverIcon">
+        <FontAwesomeIcon icon={faSquare} />
         <FontAwesomeIcon icon={faAngleUp} color="#ffffff" transform="shrink-4" />
       </span>
       <p>{count}</p>

--- a/packages/frontend/src/components/UpvoteIcon.tsx
+++ b/packages/frontend/src/components/UpvoteIcon.tsx
@@ -18,7 +18,7 @@ export const UpvoteIcon = (props: UpvoteIconProps) => {
 
   const outerStyle = {
     color: '#D0D5DD',
-    '&:hover': {
+    ':hover': {
       color: '#0E76FD',
     },
   };

--- a/packages/frontend/src/components/example/PostMessage.tsx
+++ b/packages/frontend/src/components/example/PostMessage.tsx
@@ -83,6 +83,72 @@ export const postDoxed = async (doxedContentInput: ContentUserInput, signTypedDa
   console.log('Created a non-pseudonymous post! postId', result.data.postId);
 };
 
+export const postPseudo = async (
+  nymCode: string,
+  nymSig: any,
+  nymContentInput: ContentUserInput,
+  signTypedDataAsync: any,
+) => {
+  if (nymCode && nymSig) {
+    const group = await getLatestGroup();
+    const typedNymCode = toTypedNymCode(nymCode);
+    const userPubKey = getPubKeyFromEIP712Sig(typedNymCode, nymSig);
+
+    // Get the user's merkle proof
+    const userMerkleProof = group.members.find((member) => member.pubkey === userPubKey);
+
+    // Throw if merkle proof not found (implies user not in set)
+    if (!userMerkleProof) {
+      throw new Error('User not found in set');
+    }
+
+    const merkleProof: MerkleProof = {
+      pathIndices: userMerkleProof?.indices,
+      siblings: userMerkleProof?.path.map((sibling) => BigInt(sibling)),
+      root: BigInt(group.root),
+    };
+
+    // Construct the content to sign
+    const content: Content = {
+      venue: 'nouns',
+      title: nymContentInput.title,
+      body: nymContentInput.body,
+      parentId: nymContentInput.parentId ? nymContentInput.parentId : '0x0',
+      groupRoot: group.root,
+      timestamp: Math.round(Date.now() / 1000),
+    };
+
+    // Request the user to sign the content
+    const contentSig = await signTypedDataAsync({
+      primaryType: 'Post',
+      domain: DOMAIN,
+      types: CONTENT_MESSAGE_TYPES,
+      message: content,
+    });
+
+    // Setup the prover
+    const nymProver = new NymProver({
+      enableProfiler: true,
+    });
+
+    await nymProver.initWasm();
+
+    // Generate the proof
+    const attestation = await nymProver.prove(
+      nymCode,
+      content,
+      nymSig as string,
+      contentSig as string,
+      merkleProof,
+    );
+
+    const attestationHex = Buffer.from(attestation).toString('hex');
+
+    const result = await submitPost(content, attestationHex, AttestationScheme.Nym);
+    console.log('Created a pseudonymous post! postId', result.data.postId);
+  }
+};
+
 const getPubKeyFromEIP712Sig = (typedData: EIP712TypedData, sig: string): string => {
   const { v, r, s } = fromRpcSig(sig);
   return `0x${ecrecover(
@@ -123,67 +189,6 @@ const ExamplePost = () => {
   });
 
   const { signTypedDataAsync } = useSignTypedData();
-
-  const postPseudo = async () => {
-    if (nymCode && nymSig) {
-      const group = await getLatestGroup();
-      const typedNymCode = toTypedNymCode(nymCode);
-      const userPubKey = getPubKeyFromEIP712Sig(typedNymCode, nymSig);
-
-      // Get the user's merkle proof
-      const userMerkleProof = group.members.find((member) => member.pubkey === userPubKey);
-
-      // Throw if merkle proof not found (implies user not in set)
-      if (!userMerkleProof) {
-        throw new Error('User not found in set');
-      }
-
-      const merkleProof: MerkleProof = {
-        pathIndices: userMerkleProof?.indices,
-        siblings: userMerkleProof?.path.map((sibling) => BigInt(sibling)),
-        root: BigInt(group.root),
-      };
-
-      // Construct the content to sign
-      const content: Content = {
-        venue: 'nouns',
-        title: nymContentInput.title,
-        body: nymContentInput.body,
-        parentId: nymContentInput.parentId ? nymContentInput.parentId : '0x0',
-        groupRoot: group.root,
-        timestamp: Math.round(Date.now() / 1000),
-      };
-
-      // Request the user to sign the content
-      const contentSig = await signTypedDataAsync({
-        primaryType: 'Post',
-        domain: DOMAIN,
-        types: CONTENT_MESSAGE_TYPES,
-        message: content,
-      });
-
-      // Setup the prover
-      const nymProver = new NymProver({
-        enableProfiler: true,
-      });
-
-      await nymProver.initWasm();
-
-      // Generate the proof
-      const attestation = await nymProver.prove(
-        nymCode,
-        content,
-        nymSig as string,
-        contentSig as string,
-        merkleProof,
-      );
-
-      const attestationHex = Buffer.from(attestation).toString('hex');
-
-      const result = await submitPost(content, attestationHex, AttestationScheme.Nym);
-      console.log('Created a pseudonymous post! postId', result.data.postId);
-    }
-  };
 
   return (
     <div className="flex flex-row gap-16 mt-4 justify-center">
@@ -255,7 +260,7 @@ const ExamplePost = () => {
           />
           <button
             className="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded disabled:opacity-50 disabled:cursor-not-allowed mt-4"
-            onClick={postPseudo}
+            onClick={() => postPseudo(nymCode, nymSig, nymContentInput, signTypedDataAsync)}
             disabled={!nymSig ? true : false}
           >
             Submit a pseudonymous post

--- a/packages/frontend/src/components/global/Modal.tsx
+++ b/packages/frontend/src/components/global/Modal.tsx
@@ -1,0 +1,34 @@
+import { faXmark } from '@fortawesome/free-solid-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { Dialog } from '@headlessui/react';
+import { ReactNode } from 'react';
+
+interface ModalProps {
+  width?: string;
+  isOpen: boolean;
+  handleClose: (isOpen: boolean) => void;
+  children: ReactNode;
+}
+
+export const Modal = (props: ModalProps) => {
+  const { width, isOpen, handleClose, children } = props;
+  return (
+    <Dialog open={isOpen} onClose={handleClose} className="relative z-50">
+      {/* The backdrop, rendered as a fixed sibling to the panel container */}
+      <div className="fixed inset-0 bg-black/30" aria-hidden="true" />
+      <div className="fixed inset-0 overflow-y-auto">
+        <div className="flex min-h-full items-center justify-center">
+          <Dialog.Panel
+            className="relative max-w-3xl bg-gray-50 mx-8 rounded-md"
+            style={{ width: width ? width : '100%' }}
+          >
+            <div className="absolute p-6 top-0 right-0 cursor-pointer">
+              <FontAwesomeIcon icon={faXmark} color="#98A2B3" onClick={handleClose as any} />
+            </div>
+            {children}
+          </Dialog.Panel>
+        </div>
+      </div>
+    </Dialog>
+  );
+};

--- a/packages/frontend/src/components/post/NestedReply.tsx
+++ b/packages/frontend/src/components/post/NestedReply.tsx
@@ -71,12 +71,11 @@ export const NestedReply = (replyProps: IReplyProps) => {
         <div className="flex gap-4 justify-center items-center">
           <ReplyCount count={childrenLength} />
           <div
-            className="flex gap-2 items-center cursor-pointer"
+            className="flex gap-2 items-center cursor-pointer hoverIcon"
             onClick={() => console.log('create reply')}
           >
-            <FontAwesomeIcon icon={faReply} color="#0E76FD" />
-            {/* TODO: fix blue */}
-            <p className="hover:text-blue">Reply</p>
+            <FontAwesomeIcon icon={faReply} />
+            <p className="text-gray-700">Reply</p>
           </div>
         </div>
       </div>

--- a/packages/frontend/src/components/post/PostWithReplies.tsx
+++ b/packages/frontend/src/components/post/PostWithReplies.tsx
@@ -8,10 +8,9 @@ import { IPostWithReplies } from '@/types/api';
 import { PostWithRepliesProps } from '@/types/components';
 import { ReplyCount } from './ReplyCount';
 import { UserTag } from './UserTag';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faXmark } from '@fortawesome/free-solid-svg-icons';
 import { UpvoteIcon } from '../UpvoteIcon';
 import { PrefixedHex } from '@personaelabs/nymjs';
+import { Modal } from '../global/Modal';
 
 const getPostById = async (postId: string) =>
   (await axios.get<IPostWithReplies>(`/api/v1/posts/${postId}`)).data;
@@ -19,8 +18,6 @@ const getPostById = async (postId: string) =>
 export const PostWithReplies = (postWithRepliesProps: PostWithRepliesProps) => {
   const { id, isOpen, handleClose, dateFromDescription, title, body, replyCount, userId, upvotes } =
     postWithRepliesProps;
-
-  if (isOpen) console.log({ id });
 
   //TODO: Note that this call happens regardless of if isOpen is true or not
   const { isLoading, data: singlePost } = useQuery<IPostWithReplies>({
@@ -40,51 +37,35 @@ export const PostWithReplies = (postWithRepliesProps: PostWithRepliesProps) => {
   }, [singlePost]);
 
   return (
-    <Dialog open={isOpen} onClose={handleClose} className="relative z-50">
-      {/* The backdrop, rendered as a fixed sibling to the panel container */}
-      <div className="fixed inset-0 bg-black/30" aria-hidden="true" />
-      <div className="fixed inset-0 overflow-y-auto">
-        <div className="flex min-h-full items-center justify-center">
-          <Dialog.Panel className="w-full max-w-5xl bg-white mx-8 rounded-md">
-            <div className="flex justify-end sm:hidden p-4 cursor-pointer">
-              <FontAwesomeIcon icon={faXmark} color="#98A2B3" onClick={handleClose as any} />
+    <Modal isOpen={isOpen} handleClose={handleClose}>
+      <div className="flex flex-col gap-4 py-8 px-12 md:px-12 md:py-10">
+        <div className="flex flex-col gap-3">
+          <div className="flex justify-between item-center">
+            <div className="self-start line-clamp-2">
+              <h3 className="tracking-tight">{title}</h3>
             </div>
-
-            <div className="flex flex-col gap-4 py-8 px-12 md:px-12 md:py-10">
-              <div className="flex flex-col gap-3">
-                <div className="flex justify-between item-center">
-                  <div className="self-start line-clamp-2">
-                    <h3 className="tracking-tight">{title}</h3>
-                  </div>
-                  <div className="invisible sm:visible cursor-pointer">
-                    <FontAwesomeIcon icon={faXmark} color="#98A2B3" onClick={handleClose as any} />
-                  </div>
-                </div>
-                <p>{body}</p>
-              </div>
-              <div className="h-[1px] border border-dotted border-gray-200" />
-              <div className="flex justify-between items-center">
-                <UserTag userId={userId} date={dateFromDescription} />
-                <div className="flex gap-4">
-                  <ReplyCount count={replyCount} />
-                  <div className="w-[1px] border border-dotted border-gray-200" />
-                  <UpvoteIcon count={upvotes.length} postId={id} />
-                </div>
-              </div>
-            </div>
-            <div className="flex flex-col gap-8 w-full bg-gray-50 px-12 py-8">
-              <CommentWriter parentId={id as PrefixedHex} />
-              <h4>
-                {singlePost?.replies.length}{' '}
-                {singlePost?.replies.length === 1 ? 'comment' : 'comments'}
-              </h4>
-              <div className="flex flex-col gap-6 w-full justify-center iterms-center">
-                {nestedComponentThreads}
-              </div>
-            </div>
-          </Dialog.Panel>
+          </div>
+          <p>{body}</p>
+        </div>
+        <div className="h-[1px] border border-dotted border-gray-200" />
+        <div className="flex justify-between items-center">
+          <UserTag userId={userId} date={dateFromDescription} />
+          <div className="flex gap-4">
+            <ReplyCount count={replyCount} />
+            <div className="w-[1px] border border-dotted border-gray-200" />
+            <UpvoteIcon count={upvotes.length} postId={id} />
+          </div>
         </div>
       </div>
-    </Dialog>
+      <div className="flex flex-col gap-8 w-full bg-gray-50 px-12 py-8">
+        <CommentWriter parentId={id as PrefixedHex} />
+        <h4>
+          {singlePost?.replies.length} {singlePost?.replies.length === 1 ? 'comment' : 'comments'}
+        </h4>
+        <div className="flex flex-col gap-6 w-full justify-center iterms-center">
+          {nestedComponentThreads}
+        </div>
+      </div>
+    </Modal>
   );
 };

--- a/packages/frontend/src/components/userInput/CommentWriter.tsx
+++ b/packages/frontend/src/components/userInput/CommentWriter.tsx
@@ -2,12 +2,10 @@ import { Textarea } from './Textarea';
 import { useState, useMemo } from 'react';
 import Spinner from '../global/Spinner';
 import { MainButton } from '../MainButton';
-import Image from 'next/image';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faAngleDown } from '@fortawesome/free-solid-svg-icons';
 import { postDoxed } from '../example/PostMessage';
 import { useSignTypedData } from 'wagmi';
 import { PrefixedHex } from '@personaelabs/nymjs';
+import { NymSelect } from './NymSelect';
 
 interface IWriterProps {
   parentId: PrefixedHex;
@@ -62,12 +60,7 @@ export const CommentWriter = ({ parentId }: IWriterProps) => {
 
           {/* //TODO with nym selection */}
           <div className="w-full flex gap-2 items-center justify-end text-gray-500">
-            <p className="secondary">Posting as</p>
-            <div className="bg-white flex gap-2 border items-center border-gray-200 rounded-xl px-2 py-2.5 cursor-pointer">
-              <Image alt={'profile'} src={'/anon-noun.png'} width={20} height={20} />
-              <p className="secondary">Mr. Noun</p>
-              <FontAwesomeIcon icon={faAngleDown} />
-            </div>
+            <NymSelect />
             <MainButton color="black" handler={sendPost} loading={false} message={'Send'} />
           </div>
         </div>

--- a/packages/frontend/src/components/userInput/CommentWriter.tsx
+++ b/packages/frontend/src/components/userInput/CommentWriter.tsx
@@ -3,21 +3,20 @@ import { useState, useMemo } from 'react';
 import Spinner from '../global/Spinner';
 import { MainButton } from '../MainButton';
 import { postDoxed, postPseudo } from '../example/PostMessage';
-import { useSignTypedData } from 'wagmi';
+import { useAccount, useSignTypedData } from 'wagmi';
 import { PrefixedHex } from '@personaelabs/nymjs';
 import { NymSelect } from './NymSelect';
+import { ClientNym } from '@/types/components';
 
 interface IWriterProps {
   parentId: PrefixedHex;
 }
 
 export const CommentWriter = ({ parentId }: IWriterProps) => {
-  const nymOptions = ['Doxed Name', 'Mr. Noun', 'Pseudo Nym'];
-
   //TODO: render title box if no commentId exists (distinguish between reply and top-level post)
   const [body, setCommentMsg] = useState<string>('');
   const [title, setTitleMsg] = useState<string>('');
-  const [nym, setNym] = useState<string>(nymOptions[0]);
+  const [nym, setNym] = useState<ClientNym>({ nymSig: '0x0', nymCode: 'Doxed' });
 
   // TODO
   const someDbQuery = useMemo(() => true, []);
@@ -25,16 +24,13 @@ export const CommentWriter = ({ parentId }: IWriterProps) => {
   // TODO
   const canPost = useMemo(() => true, []);
 
-  const nymCode = 'test';
-  const nymSig = 'test';
-
   const { signTypedDataAsync } = useSignTypedData();
 
   const sendPost = () => {
-    if (nym === 'Doxed Name') {
+    if (nym.nymCode === 'Doxed Name') {
       postDoxed({ title, body, parentId }, signTypedDataAsync);
     } else {
-      postPseudo(nymCode, nymSig, { title, body, parentId }, signTypedDataAsync);
+      postPseudo(nym.nymCode, nym.nymSig, { title, body, parentId }, signTypedDataAsync);
     }
   };
 
@@ -67,7 +63,7 @@ export const CommentWriter = ({ parentId }: IWriterProps) => {
             </div>
           </div>
           <div className="w-full flex gap-2 items-center justify-end text-gray-500">
-            <NymSelect nyms={nymOptions} selectedNym={nym} setSelectedNym={setNym} />
+            <NymSelect selectedNym={nym} setSelectedNym={setNym} />
             <MainButton color="black" handler={sendPost} loading={false} message={'Send'} />
           </div>
         </div>

--- a/packages/frontend/src/components/userInput/CommentWriter.tsx
+++ b/packages/frontend/src/components/userInput/CommentWriter.tsx
@@ -2,7 +2,7 @@ import { Textarea } from './Textarea';
 import { useState, useMemo } from 'react';
 import Spinner from '../global/Spinner';
 import { MainButton } from '../MainButton';
-import { postDoxed } from '../example/PostMessage';
+import { postDoxed, postPseudo } from '../example/PostMessage';
 import { useSignTypedData } from 'wagmi';
 import { PrefixedHex } from '@personaelabs/nymjs';
 import { NymSelect } from './NymSelect';
@@ -12,9 +12,12 @@ interface IWriterProps {
 }
 
 export const CommentWriter = ({ parentId }: IWriterProps) => {
+  const nymOptions = ['Doxed Name', 'Mr. Noun', 'Pseudo Nym'];
+
   //TODO: render title box if no commentId exists (distinguish between reply and top-level post)
   const [body, setCommentMsg] = useState<string>('');
   const [title, setTitleMsg] = useState<string>('');
+  const [nym, setNym] = useState<string>(nymOptions[0]);
 
   // TODO
   const someDbQuery = useMemo(() => true, []);
@@ -22,11 +25,17 @@ export const CommentWriter = ({ parentId }: IWriterProps) => {
   // TODO
   const canPost = useMemo(() => true, []);
 
+  const nymCode = 'test';
+  const nymSig = 'test';
+
   const { signTypedDataAsync } = useSignTypedData();
 
   const sendPost = () => {
-    console.log(`posting`, title, body);
-    postDoxed({ title, body, parentId }, signTypedDataAsync);
+    if (nym === 'Doxed Name') {
+      postDoxed({ title, body, parentId }, signTypedDataAsync);
+    } else {
+      postPseudo(nymCode, nymSig, { title, body, parentId }, signTypedDataAsync);
+    }
   };
 
   return (
@@ -57,10 +66,8 @@ export const CommentWriter = ({ parentId }: IWriterProps) => {
               ></Textarea>
             </div>
           </div>
-
-          {/* //TODO with nym selection */}
           <div className="w-full flex gap-2 items-center justify-end text-gray-500">
-            <NymSelect />
+            <NymSelect nyms={nymOptions} selectedNym={nym} setSelectedNym={setNym} />
             <MainButton color="black" handler={sendPost} loading={false} message={'Send'} />
           </div>
         </div>

--- a/packages/frontend/src/components/userInput/CommentWriter.tsx
+++ b/packages/frontend/src/components/userInput/CommentWriter.tsx
@@ -27,7 +27,7 @@ export const CommentWriter = ({ parentId }: IWriterProps) => {
   const { signTypedDataAsync } = useSignTypedData();
 
   const sendPost = () => {
-    if (nym.nymCode === 'Doxed Name') {
+    if (nym.nymCode === 'Doxed') {
       postDoxed({ title, body, parentId }, signTypedDataAsync);
     } else {
       postPseudo(nym.nymCode, nym.nymSig, { title, body, parentId }, signTypedDataAsync);

--- a/packages/frontend/src/components/userInput/NewNym.tsx
+++ b/packages/frontend/src/components/userInput/NewNym.tsx
@@ -8,7 +8,7 @@ import { ClientNym } from '@/types/components';
 
 interface NewNymProps {
   isOpen: boolean;
-  handleClose: (isOpen: boolean) => void;
+  handleClose: () => void;
   nymOptions: ClientNym[];
   setNymOptions: (nymOptions: ClientNym[]) => void;
 }
@@ -54,6 +54,7 @@ export const NewNym = (props: NewNymProps) => {
       storeNym(nymSig);
     }
     setNymOptions([...nymOptions, { nymCode, nymSig }]);
+    handleClose();
   };
   return (
     <Modal width="50%" isOpen={isOpen} handleClose={handleClose}>

--- a/packages/frontend/src/components/userInput/NewNym.tsx
+++ b/packages/frontend/src/components/userInput/NewNym.tsx
@@ -2,6 +2,8 @@ import Image from 'next/image';
 import { Modal } from '../global/Modal';
 import { useState } from 'react';
 import { MainButton } from '../MainButton';
+import { NYM_CODE_TYPE, DOMAIN } from '@personaelabs/nymjs';
+import { useSignTypedData } from 'wagmi';
 
 interface NewNymProps {
   isOpen: boolean;
@@ -10,10 +12,17 @@ interface NewNymProps {
 
 export const NewNym = (props: NewNymProps) => {
   const { isOpen, handleClose } = props;
-
-  const confirmNewNym = () => console.log('confirm new nym');
-
   const [nymName, setNymName] = useState<string>('');
+
+  const { data: nymSig, signTypedData: signNymCode } = useSignTypedData({
+    primaryType: 'Nym',
+    domain: DOMAIN,
+    types: NYM_CODE_TYPE,
+    message: {
+      nymName,
+    },
+  });
+
   return (
     <Modal width="50%" isOpen={isOpen} handleClose={handleClose}>
       <div className="flex flex-col gap-4 py-8 px-12 md:px-12 md:py-10">
@@ -23,10 +32,11 @@ export const NewNym = (props: NewNymProps) => {
         <p className="text-gray-700">
           What does it mean to create a new nym? Any warnings the user should know beforehand?
         </p>
-        <div className="flex justify-start gap-2">
-          <Image alt={'profile'} src={'/anon-noun.png'} width={20} height={20} />
-          <div className="w-40 relative border border-gray-200 rounded-md px-4 py-2.5">
+        <div className="flex justify-start items-center gap-2">
+          <Image alt={'profile'} src={'/anon-noun.png'} width={24} height={24} />
+          <div className="relative border border-gray-200 rounded-md px-2 py-1">
             <input
+              className="outline-none bg-transparent"
               type="text"
               placeholder="Name"
               value={nymName}
@@ -36,7 +46,13 @@ export const NewNym = (props: NewNymProps) => {
           <p className="secondary">#0000</p>
         </div>
         <div className="flex justify-center">
-          <MainButton color="#0E76FD" message="Confirm" loading={false} handler={confirmNewNym} />
+          <MainButton
+            color="#0E76FD"
+            message="Confirm"
+            loading={false}
+            handler={signNymCode}
+            disabled={nymName !== '' && !nymSig ? false : true}
+          />
         </div>
       </div>
     </Modal>

--- a/packages/frontend/src/components/userInput/NewNym.tsx
+++ b/packages/frontend/src/components/userInput/NewNym.tsx
@@ -12,16 +12,20 @@ interface NewNymProps {
 
 export const NewNym = (props: NewNymProps) => {
   const { isOpen, handleClose } = props;
-  const [nymName, setNymName] = useState<string>('');
+  const [nymCode, setnymCode] = useState<string>('');
 
   const { data: nymSig, signTypedData: signNymCode } = useSignTypedData({
     primaryType: 'Nym',
     domain: DOMAIN,
     types: NYM_CODE_TYPE,
     message: {
-      nymName,
+      nymCode,
     },
   });
+
+  const storeNym = () => {
+    localStorage.setItem(nymSig as string, nymCode);
+  };
 
   return (
     <Modal width="50%" isOpen={isOpen} handleClose={handleClose}>
@@ -39,8 +43,8 @@ export const NewNym = (props: NewNymProps) => {
               className="outline-none bg-transparent"
               type="text"
               placeholder="Name"
-              value={nymName}
-              onChange={(event) => setNymName(event.target.value)}
+              value={nymCode}
+              onChange={(event) => setnymCode(event.target.value)}
             />
           </div>
           <p className="secondary">#0000</p>
@@ -50,8 +54,12 @@ export const NewNym = (props: NewNymProps) => {
             color="#0E76FD"
             message="Confirm"
             loading={false}
-            handler={signNymCode}
-            disabled={nymName !== '' && !nymSig ? false : true}
+            handler={async () => {
+              await signNymCode();
+              if (nymSig) storeNym();
+              else console.log('nym could not be created');
+            }}
+            disabled={nymCode !== '' && !nymSig ? false : true}
           />
         </div>
       </div>

--- a/packages/frontend/src/components/userInput/NewNym.tsx
+++ b/packages/frontend/src/components/userInput/NewNym.tsx
@@ -1,0 +1,44 @@
+import Image from 'next/image';
+import { Modal } from '../global/Modal';
+import { useState } from 'react';
+import { MainButton } from '../MainButton';
+
+interface NewNymProps {
+  isOpen: boolean;
+  handleClose: (isOpen: boolean) => void;
+}
+
+export const NewNym = (props: NewNymProps) => {
+  const { isOpen, handleClose } = props;
+
+  const confirmNewNym = () => console.log('confirm new nym');
+
+  const [nymName, setNymName] = useState<string>('');
+  return (
+    <Modal width="50%" isOpen={isOpen} handleClose={handleClose}>
+      <div className="flex flex-col gap-4 py-8 px-12 md:px-12 md:py-10">
+        <div className="flex justify-start">
+          <h3>Create a new nym</h3>
+        </div>
+        <p className="text-gray-700">
+          What does it mean to create a new nym? Any warnings the user should know beforehand?
+        </p>
+        <div className="flex justify-start gap-2">
+          <Image alt={'profile'} src={'/anon-noun.png'} width={20} height={20} />
+          <div className="w-40 relative border border-gray-200 rounded-md px-4 py-2.5">
+            <input
+              type="text"
+              placeholder="Name"
+              value={nymName}
+              onChange={(event) => setNymName(event.target.value)}
+            />
+          </div>
+          <p className="secondary">#0000</p>
+        </div>
+        <div className="flex justify-center">
+          <MainButton color="#0E76FD" message="Confirm" loading={false} handler={confirmNewNym} />
+        </div>
+      </div>
+    </Modal>
+  );
+};

--- a/packages/frontend/src/components/userInput/NewPost.tsx
+++ b/packages/frontend/src/components/userInput/NewPost.tsx
@@ -1,7 +1,5 @@
-import { Dialog } from '@headlessui/react';
 import { CommentWriter } from './CommentWriter';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faXmark } from '@fortawesome/free-solid-svg-icons';
+import { Modal } from '../global/Modal';
 
 interface NewPostProps {
   isOpen: boolean;
@@ -11,26 +9,13 @@ export const NewPost = (props: NewPostProps) => {
   const { isOpen, handleClose } = props;
 
   return (
-    <Dialog open={isOpen} onClose={handleClose} className="relative z-50">
-      <div className="fixed inset-0 bg-black/30" aria-hidden="true" />
-      <div className="fixed inset-0 overflow-y-auto">
-        <div className="flex min-h-full items-center justify-center">
-          <Dialog.Panel className="w-full max-w-3xl bg-gray-50 mx-8 rounded-md">
-            <div className="flex justify-end sm:hidden p-4 cursor-pointer">
-              <FontAwesomeIcon icon={faXmark} color="#98A2B3" onClick={handleClose as any} />
-            </div>
-            <div className="flex flex-col gap-4 py-8 px-12 md:px-12 md:py-10">
-              <div className="flex justify-between">
-                <h3>Start a discussion here</h3>
-                <div className="invisible sm:visible cursor-pointer">
-                  <FontAwesomeIcon icon={faXmark} color="#98A2B3" onClick={handleClose as any} />
-                </div>
-              </div>
-              <CommentWriter parentId={'0x0'} />
-            </div>
-          </Dialog.Panel>
+    <Modal isOpen={isOpen} handleClose={handleClose}>
+      <div className="flex flex-col gap-4 py-8 px-12 md:px-12 md:py-10">
+        <div className="flex justify-start">
+          <h3>Start a discussion here</h3>
         </div>
+        <CommentWriter parentId={'0x0'} />
       </div>
-    </Dialog>
+    </Modal>
   );
 };

--- a/packages/frontend/src/components/userInput/NymSelect.tsx
+++ b/packages/frontend/src/components/userInput/NymSelect.tsx
@@ -11,18 +11,18 @@ interface NymSelectProps {
   setSelectedNym: (selectedNym: ClientNym) => void;
 }
 
+const getNymOptions = (address: string | undefined) => {
+  const nymOptionsString = address ? localStorage.getItem(address) : '';
+  return nymOptionsString ? (JSON.parse(nymOptionsString) as ClientNym[]) : [];
+};
+
 export const NymSelect = (props: NymSelectProps) => {
   const { address } = useAccount();
   const { selectedNym, setSelectedNym } = props;
 
   const [openSelect, setOpenSelect] = useState<boolean>(false);
   const [openNewNym, setOpenNewNym] = useState<boolean>(false);
-  const [nymOptions, setNymOptions] = useState<ClientNym[]>([]);
-
-  useEffect(() => {
-    const nymOptionsString = address ? localStorage.getItem(address) : '';
-    if (nymOptionsString) setNymOptions(JSON.parse(nymOptionsString));
-  }, [address]);
+  const [nymOptions, setNymOptions] = useState<ClientNym[]>(getNymOptions(address));
 
   return (
     <>

--- a/packages/frontend/src/components/userInput/NymSelect.tsx
+++ b/packages/frontend/src/components/userInput/NymSelect.tsx
@@ -1,0 +1,50 @@
+import { faAngleDown, faAngleUp, faCheck, faPlus } from '@fortawesome/free-solid-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import Image from 'next/image';
+import { useState } from 'react';
+import { NewNym } from './NewNym';
+
+interface NymSelectProps {}
+
+export const NymSelect = (props: NymSelectProps) => {
+  const [openSelect, setOpenSelect] = useState<boolean>(false);
+  const [openNewNym, setOpenNewNym] = useState<boolean>(false);
+
+  return (
+    <>
+      {openNewNym ? <NewNym isOpen={openNewNym} handleClose={() => setOpenNewNym(false)} /> : null}
+      <p className="secondary">Posting as</p>
+      <div className="relative">
+        <div
+          className="bg-white flex gap-2 border items-center border-gray-200 rounded-xl px-2 py-2.5 cursor-pointer"
+          onClick={() => setOpenSelect(!openSelect)}
+        >
+          <Image alt={'profile'} src={'/anon-noun.png'} width={20} height={20} />
+          <p>Mr. Noun</p>
+          <FontAwesomeIcon icon={openSelect ? faAngleUp : faAngleDown} />
+        </div>
+        {openSelect ? (
+          <div className="absolute top-full left-0 w-full bg-white mt-2 border items-center border-gray-200 rounded-xl cursor-pointer">
+            <div className="flex gap-2 px-2 py-2.5 rounded-xl hover:bg-gray-100">
+              <Image alt={'profile'} src={'/anon-noun.png'} width={20} height={20} />
+              <p>Mr. Noun</p>
+              <FontAwesomeIcon icon={faCheck} className="hidden" />
+            </div>
+            <div className="flex gap-2 px-2 py-2.5 rounded-xl hover:bg-gray-100">
+              <Image alt={'profile'} src={'/anon-noun.png'} width={20} height={20} />
+              <p>Mr. Noun</p>
+              <FontAwesomeIcon icon={faCheck} className="hidden" />
+            </div>
+            <div
+              className="items-center flex gap-2 px-2 py-2.5 rounded-xl hover:bg-gray-100"
+              onClick={() => setOpenNewNym(true)}
+            >
+              <FontAwesomeIcon icon={faPlus} className="w-5" color={'#0E76FD'} />
+              <p>New Nym</p>
+            </div>
+          </div>
+        ) : null}
+      </div>
+    </>
+  );
+};

--- a/packages/frontend/src/components/userInput/NymSelect.tsx
+++ b/packages/frontend/src/components/userInput/NymSelect.tsx
@@ -4,9 +4,15 @@ import Image from 'next/image';
 import { useState } from 'react';
 import { NewNym } from './NewNym';
 
-interface NymSelectProps {}
+interface NymSelectProps {
+  nyms: string[];
+  selectedNym: string;
+  setSelectedNym: (selectedNym: string) => void;
+}
 
 export const NymSelect = (props: NymSelectProps) => {
+  const { nyms, selectedNym, setSelectedNym } = props;
+
   const [openSelect, setOpenSelect] = useState<boolean>(false);
   const [openNewNym, setOpenNewNym] = useState<boolean>(false);
 
@@ -14,27 +20,37 @@ export const NymSelect = (props: NymSelectProps) => {
     <>
       {openNewNym ? <NewNym isOpen={openNewNym} handleClose={() => setOpenNewNym(false)} /> : null}
       <p className="secondary">Posting as</p>
-      <div className="relative">
+      <div className="relative w-max">
         <div
           className="bg-white flex gap-2 border items-center border-gray-200 rounded-xl px-2 py-2.5 cursor-pointer"
           onClick={() => setOpenSelect(!openSelect)}
         >
           <Image alt={'profile'} src={'/anon-noun.png'} width={20} height={20} />
-          <p>Mr. Noun</p>
+          <p>{selectedNym}</p>
           <FontAwesomeIcon icon={openSelect ? faAngleUp : faAngleDown} />
         </div>
         {openSelect ? (
-          <div className="absolute top-full left-0 w-full bg-white mt-2 border items-center border-gray-200 rounded-xl cursor-pointer">
-            <div className="flex gap-2 px-2 py-2.5 rounded-xl hover:bg-gray-100">
-              <Image alt={'profile'} src={'/anon-noun.png'} width={20} height={20} />
-              <p>Mr. Noun</p>
-              <FontAwesomeIcon icon={faCheck} className="hidden" />
-            </div>
-            <div className="flex gap-2 px-2 py-2.5 rounded-xl hover:bg-gray-100">
-              <Image alt={'profile'} src={'/anon-noun.png'} width={20} height={20} />
-              <p>Mr. Noun</p>
-              <FontAwesomeIcon icon={faCheck} className="hidden" />
-            </div>
+          <div className="w-max absolute top-full left-0 w-full bg-white mt-2 border items-center border-gray-200 rounded-xl cursor-pointer">
+            {nyms.map((nym) => (
+              <div
+                key={nym}
+                className="flex justify-between gap-2 items-center px-2 py-2.5 rounded-xl hover:bg-gray-100"
+                onClick={() => {
+                  setSelectedNym(nym);
+                  setOpenSelect(false);
+                }}
+              >
+                <div className="flex gap-2 justify-start">
+                  <Image alt={'profile'} src={'/anon-noun.png'} width={20} height={20} />
+                  <p>{nym}</p>
+                </div>
+                <FontAwesomeIcon
+                  icon={faCheck}
+                  color={'#0E76FD'}
+                  className={`${nym === selectedNym ? 'opacity-1' : 'opacity-0'}`}
+                />
+              </div>
+            ))}
             <div
               className="items-center flex gap-2 px-2 py-2.5 rounded-xl hover:bg-gray-100"
               onClick={() => setOpenNewNym(true)}

--- a/packages/frontend/src/components/userInput/NymSelect.tsx
+++ b/packages/frontend/src/components/userInput/NymSelect.tsx
@@ -1,24 +1,39 @@
 import { faAngleDown, faAngleUp, faCheck, faPlus } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import Image from 'next/image';
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import { NewNym } from './NewNym';
+import { ClientNym } from '@/types/components';
+import { useAccount } from 'wagmi';
 
 interface NymSelectProps {
-  nyms: string[];
-  selectedNym: string;
-  setSelectedNym: (selectedNym: string) => void;
+  selectedNym: ClientNym;
+  setSelectedNym: (selectedNym: ClientNym) => void;
 }
 
 export const NymSelect = (props: NymSelectProps) => {
-  const { nyms, selectedNym, setSelectedNym } = props;
+  const { address } = useAccount();
+  const { selectedNym, setSelectedNym } = props;
 
   const [openSelect, setOpenSelect] = useState<boolean>(false);
   const [openNewNym, setOpenNewNym] = useState<boolean>(false);
+  const [nymOptions, setNymOptions] = useState<ClientNym[]>([]);
+
+  const nymOptionsString = address ? localStorage.getItem(address) : '';
+  if (nymOptionsString) setNymOptions(JSON.parse(nymOptionsString));
+
+  console.log({ nymOptions });
 
   return (
     <>
-      {openNewNym ? <NewNym isOpen={openNewNym} handleClose={() => setOpenNewNym(false)} /> : null}
+      {openNewNym ? (
+        <NewNym
+          isOpen={openNewNym}
+          handleClose={() => setOpenNewNym(false)}
+          nymOptions={nymOptions}
+          setNymOptions={setNymOptions}
+        />
+      ) : null}
       <p className="secondary">Posting as</p>
       <div className="relative w-max">
         <div
@@ -26,31 +41,32 @@ export const NymSelect = (props: NymSelectProps) => {
           onClick={() => setOpenSelect(!openSelect)}
         >
           <Image alt={'profile'} src={'/anon-noun.png'} width={20} height={20} />
-          <p>{selectedNym}</p>
+          <p>{selectedNym.nymCode}</p>
           <FontAwesomeIcon icon={openSelect ? faAngleUp : faAngleDown} />
         </div>
         {openSelect ? (
           <div className="w-max absolute top-full left-0 w-full bg-white mt-2 border items-center border-gray-200 rounded-xl cursor-pointer">
-            {nyms.map((nym) => (
-              <div
-                key={nym}
-                className="flex justify-between gap-2 items-center px-2 py-2.5 rounded-xl hover:bg-gray-100"
-                onClick={() => {
-                  setSelectedNym(nym);
-                  setOpenSelect(false);
-                }}
-              >
-                <div className="flex gap-2 justify-start">
-                  <Image alt={'profile'} src={'/anon-noun.png'} width={20} height={20} />
-                  <p>{nym}</p>
+            {nymOptions &&
+              nymOptions.map((nym) => (
+                <div
+                  key={nym.nymSig}
+                  className="flex justify-between gap-2 items-center px-2 py-2.5 rounded-xl hover:bg-gray-100"
+                  onClick={() => {
+                    setSelectedNym(nym);
+                    setOpenSelect(false);
+                  }}
+                >
+                  <div className="flex gap-2 justify-start">
+                    <Image alt={'profile'} src={'/anon-noun.png'} width={20} height={20} />
+                    <p>{nym.nymCode}</p>
+                  </div>
+                  <FontAwesomeIcon
+                    icon={faCheck}
+                    color={'#0E76FD'}
+                    className={`${nym.nymSig === selectedNym.nymSig ? 'opacity-1' : 'opacity-0'}`}
+                  />
                 </div>
-                <FontAwesomeIcon
-                  icon={faCheck}
-                  color={'#0E76FD'}
-                  className={`${nym === selectedNym ? 'opacity-1' : 'opacity-0'}`}
-                />
-              </div>
-            ))}
+              ))}
             <div
               className="items-center flex gap-2 px-2 py-2.5 rounded-xl hover:bg-gray-100"
               onClick={() => setOpenNewNym(true)}

--- a/packages/frontend/src/components/userInput/NymSelect.tsx
+++ b/packages/frontend/src/components/userInput/NymSelect.tsx
@@ -1,7 +1,7 @@
 import { faAngleDown, faAngleUp, faCheck, faPlus } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import Image from 'next/image';
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { NewNym } from './NewNym';
 import { ClientNym } from '@/types/components';
 import { useAccount } from 'wagmi';
@@ -19,10 +19,10 @@ export const NymSelect = (props: NymSelectProps) => {
   const [openNewNym, setOpenNewNym] = useState<boolean>(false);
   const [nymOptions, setNymOptions] = useState<ClientNym[]>([]);
 
-  const nymOptionsString = address ? localStorage.getItem(address) : '';
-  if (nymOptionsString) setNymOptions(JSON.parse(nymOptionsString));
-
-  console.log({ nymOptions });
+  useEffect(() => {
+    const nymOptionsString = address ? localStorage.getItem(address) : '';
+    if (nymOptionsString) setNymOptions(JSON.parse(nymOptionsString));
+  }, [address]);
 
   return (
     <>

--- a/packages/frontend/src/styles/globals.css
+++ b/packages/frontend/src/styles/globals.css
@@ -80,4 +80,11 @@
     resize: none;
     background: white;
   }
+
+  .hoverIcon {
+    color: #d0d5dd;
+  }
+  .hoverIcon:hover {
+    color: #0e76fd;
+  }
 }

--- a/packages/frontend/types/components/index.ts
+++ b/packages/frontend/types/components/index.ts
@@ -9,3 +9,8 @@ export type PostWithRepliesProps = IRootPost & {
   handleClose: (isOpen: boolean) => void;
   dateFromDescription: string;
 };
+
+export type ClientNym = {
+  nymCode: string;
+  nymSig: string;
+};


### PR DESCRIPTION
#### Options menu
On `openSelect`, check local storage and get list of pre-created nyms
1. Get doxed id
2. Existing nyms (if any)
3. Option to create new nym

#### Posting Flow
**Case 1:** User posts with doxed id
- Pass doxed id to `postDoxed`

**Case 2:** User selects nym from pre-existing options
- Pass nymSig and nymName from local storage to `postPseudo`

**Case 3:** User creates new nym
- `signNym` with nymName, get nymSig
- Pass nymSig and nymName to `postPseudo`

**Questions**
_Should the be an option to remove an existing nym?_