### PR TITLE
Modal Fixes

### DIFF
--- a/packages/frontend/src/components/Header.tsx
+++ b/packages/frontend/src/components/Header.tsx
@@ -1,0 +1,39 @@
+import { motion } from 'framer-motion';
+import ConnectWallet from './ConnectWallet';
+
+export const Header = () => {
+  return (
+    <div className="bg-black dots w-full">
+      <div className="pt-8">
+        <nav className="pr-6 flex justify-end">
+          <ConnectWallet />
+        </nav>
+        <div className="max-w-7xl mx-auto pt-12 pb-8 px-4 sm:px-6 lg:px-8">
+          <div className="text-center md:text-center max-w-2xl mx-auto">
+            <motion.h1
+              initial={{ y: -12, opacity: 0 }}
+              animate={{ y: 0, opacity: 1 }}
+              transition={{ duration: 0.3 }}
+              className="leading-[40px] md:leading-14"
+            >
+              Give Feedback On Proposals Anonymously
+            </motion.h1>
+            <motion.h4
+              initial={{ y: -12, opacity: 0 }}
+              animate={{ y: 0, opacity: 1 }}
+              transition={{ duration: 0.3, delay: 0.1 }}
+              className="mt-4 md:leading-8 font-normal text-white"
+            >
+              Anoun allows noun-holders to give feedback on proposals while maintaining their
+              privacy using zero-knowledge proofs.{' '}
+            </motion.h4>
+          </div>
+        </div>
+      </div>
+      <div className="flex justify-center">
+        {/* eslint-disable-next-line @next/next/no-img-element */}
+        <img className="w-40" src="/nouns.png" alt="nouns" />
+      </div>
+    </div>
+  );
+};

--- a/packages/frontend/src/components/Posts.tsx
+++ b/packages/frontend/src/components/Posts.tsx
@@ -1,15 +1,14 @@
-import { motion } from 'framer-motion';
 import { Post } from '@/components/post/Post';
 import { useQuery } from '@tanstack/react-query';
 import axios from 'axios';
 import { IRootPost } from '@/types/api';
 import Spinner from './global/Spinner';
-import ConnectWallet from './ConnectWallet';
 import { MainButton } from './MainButton';
 import { useMemo, useState } from 'react';
 import { NewPost } from './userInput/NewPost';
 import { Upvote } from './Upvote';
 import { PostWithReplies } from './post/PostWithReplies';
+import { Header } from './Header';
 
 const getPosts = async () => (await axios.get<IRootPost[]>('/api/v1/posts')).data;
 
@@ -50,49 +49,13 @@ export default function Posts(props: PostsProps) {
 
   return (
     <>
-      <NewPost
-        isOpen={newPostOpen}
-        handleClose={() => setNewPostOpen(false)}
-        onSuccess={manualRefetch}
-      />
-      {openPost ? (
-        <PostWithReplies {...openPost} isOpen={true} handleClose={() => setOpenPostId('')} />
+      {newPostOpen ? (
+        <NewPost handleClose={() => setNewPostOpen(false)} onSuccess={manualRefetch} />
       ) : null}
-
+      {openPost ? <PostWithReplies {...openPost} handleClose={() => setOpenPostId('')} /> : null}
+      <Header />
       <main className="flex w-full flex-col justify-center items-center">
         <div className="w-full bg-gray-50 flex flex-col justify-center items-center">
-          <div className="bg-black dots w-full">
-            <div className="pt-8">
-              <nav className="pr-6 flex justify-end">
-                <ConnectWallet />
-              </nav>
-              <div className="max-w-7xl mx-auto pt-12 pb-8 px-4 sm:px-6 lg:px-8">
-                <div className="text-center md:text-center max-w-2xl mx-auto">
-                  <motion.h1
-                    initial={{ y: -12, opacity: 0 }}
-                    animate={{ y: 0, opacity: 1 }}
-                    transition={{ duration: 0.3 }}
-                    className="leading-[40px] md:leading-14"
-                  >
-                    Give Feedback On Proposals Anonymously
-                  </motion.h1>
-                  <motion.h4
-                    initial={{ y: -12, opacity: 0 }}
-                    animate={{ y: 0, opacity: 1 }}
-                    transition={{ duration: 0.3, delay: 0.1 }}
-                    className="mt-4 md:leading-8 font-normal text-white"
-                  >
-                    Anoun allows noun-holders to give feedback on proposals while maintaining their
-                    privacy using zero-knowledge proofs.{' '}
-                  </motion.h4>
-                </div>
-              </div>
-            </div>
-            <div className="flex justify-center">
-              {/* eslint-disable-next-line @next/next/no-img-element */}
-              <img className="w-40" src="/nouns.png" alt="nouns" />
-            </div>
-          </div>
           <div className="bg-gray-50 min-h-screen w-full">
             <div className="flex flex-col gap-8 max-w-3xl mx-auto py-5 md:py-10 px-3 md:px-0">
               <div className="flex justify-end">

--- a/packages/frontend/src/components/Upvote.tsx
+++ b/packages/frontend/src/components/Upvote.tsx
@@ -49,16 +49,11 @@ export const Upvote = (props: UpvoteIconProps) => {
     <>
       {showVoteWarning ? (
         <UpvoteWarning
-          isOpen={showVoteWarning}
           handleClose={() => setShowVoteWarning(false)}
           upvoteHandler={upvoteHandler}
         />
       ) : showWalletWarning ? (
-        <WalletWarning
-          isOpen={showWalletWarning}
-          handleClose={() => setShowWalletWarning(false)}
-          action="upvote"
-        />
+        <WalletWarning handleClose={() => setShowWalletWarning(false)} action="upvote" />
       ) : null}
       <div
         onClick={handleClick}

--- a/packages/frontend/src/components/Upvote.tsx
+++ b/packages/frontend/src/components/Upvote.tsx
@@ -31,9 +31,14 @@ export const Upvote = (props: UpvoteIconProps) => {
   const hasUpvoted = useMemo(getHasUpvoted, [address, upvotes]);
 
   const upvoteHandler = async () => {
-    await submitUpvote(postId, signTypedDataAsync);
-    onSuccess();
-    setShowVoteWarning(false);
+    try {
+      await submitUpvote(postId, signTypedDataAsync);
+      onSuccess();
+      setShowVoteWarning(false);
+    } catch (error) {
+      //TODO: error handling
+      console.error(error);
+    }
   };
 
   const handleClick = () => {

--- a/packages/frontend/src/components/UpvoteWarning.tsx
+++ b/packages/frontend/src/components/UpvoteWarning.tsx
@@ -4,18 +4,17 @@ import { MainButton } from './MainButton';
 import { useAccount } from 'wagmi';
 
 interface UpvoteWarningProps {
-  isOpen: boolean;
   handleClose: () => void;
   upvoteHandler: () => void;
 }
 
 export const UpvoteWarning = (props: UpvoteWarningProps) => {
-  const { isOpen, handleClose, upvoteHandler } = props;
+  const { handleClose, upvoteHandler } = props;
 
   const { address } = useAccount();
 
   return (
-    <Modal width="50%" isOpen={isOpen} handleClose={handleClose}>
+    <Modal width="50%" handleClose={handleClose}>
       <div className="flex flex-col gap-4 py-8 px-12 md:px-12 md:py-10">
         <h3>You&apos;re voting as</h3>
         <div className="w-max flex gap-2 items-center rounded-xl px-2 py-2.5 border border-gray-200">

--- a/packages/frontend/src/components/WalletWarning.tsx
+++ b/packages/frontend/src/components/WalletWarning.tsx
@@ -1,5 +1,6 @@
 import ConnectWallet from './ConnectWallet';
 import { Modal } from './global/Modal';
+import { useAccount } from 'wagmi';
 
 interface WalletWarningProps {
   handleClose: () => void;
@@ -8,19 +9,25 @@ interface WalletWarningProps {
 
 export const WalletWarning = (props: WalletWarningProps) => {
   const { handleClose, action } = props;
+  const { address } = useAccount();
 
   return (
-    <Modal width="50%" handleClose={handleClose}>
-      <div className="flex flex-col gap-4 py-8 px-12 md:px-12 md:py-10">
-        <h3>Connect a wallet to {action}</h3>
-        <p className="text-gray-700">
-          Hey everyone, I was just reading about the challenges facing web3 adoption and I think one
-          of the key issues is creating a more user-friendly ecosystem. What do you all think?
-        </p>
-        <div className="flex justify-center">
-          <ConnectWallet />
-        </div>
-      </div>
-    </Modal>
+    <>
+      {address ? null : (
+        <Modal width="50%" handleClose={handleClose}>
+          <div className="flex flex-col gap-4 py-8 px-12 md:px-12 md:py-10">
+            <h3>Connect a wallet to {action}</h3>
+            <p className="text-gray-700">
+              Hey everyone, I was just reading about the challenges facing web3 adoption and I think
+              one of the key issues is creating a more user-friendly ecosystem. What do you all
+              think?
+            </p>
+            <div className="flex justify-center">
+              <ConnectWallet />
+            </div>
+          </div>
+        </Modal>
+      )}
+    </>
   );
 };

--- a/packages/frontend/src/components/WalletWarning.tsx
+++ b/packages/frontend/src/components/WalletWarning.tsx
@@ -2,16 +2,15 @@ import ConnectWallet from './ConnectWallet';
 import { Modal } from './global/Modal';
 
 interface WalletWarningProps {
-  isOpen: boolean;
   handleClose: () => void;
   action: string;
 }
 
 export const WalletWarning = (props: WalletWarningProps) => {
-  const { isOpen, handleClose, action } = props;
+  const { handleClose, action } = props;
 
   return (
-    <Modal width="50%" isOpen={isOpen} handleClose={handleClose}>
+    <Modal width="50%" handleClose={handleClose}>
       <div className="flex flex-col gap-4 py-8 px-12 md:px-12 md:py-10">
         <h3>Connect a wallet to {action}</h3>
         <p className="text-gray-700">

--- a/packages/frontend/src/components/global/Modal.tsx
+++ b/packages/frontend/src/components/global/Modal.tsx
@@ -5,15 +5,14 @@ import { ReactNode } from 'react';
 
 interface ModalProps {
   width?: string;
-  isOpen: boolean;
   handleClose: () => void;
   children: ReactNode;
 }
 
 export const Modal = (props: ModalProps) => {
-  const { width, isOpen, handleClose, children } = props;
+  const { width, handleClose, children } = props;
   return (
-    <Dialog open={isOpen} onClose={handleClose} className="relative z-50">
+    <Dialog open={true} onClose={handleClose} className="relative z-50">
       {/* The backdrop, rendered as a fixed sibling to the panel container */}
       <div className="fixed inset-0 bg-black/30" aria-hidden="true" />
       <div className="fixed inset-0 overflow-y-auto">

--- a/packages/frontend/src/components/global/Modal.tsx
+++ b/packages/frontend/src/components/global/Modal.tsx
@@ -5,18 +5,22 @@ import { ReactNode } from 'react';
 
 interface ModalProps {
   width?: string;
+  startAtTop?: boolean;
   handleClose: () => void;
   children: ReactNode;
 }
 
 export const Modal = (props: ModalProps) => {
-  const { width, handleClose, children } = props;
+  const { width, startAtTop, handleClose, children } = props;
   return (
     <Dialog open={true} onClose={handleClose} className="relative z-50">
       {/* The backdrop, rendered as a fixed sibling to the panel container */}
       <div className="fixed inset-0 bg-black/30" aria-hidden="true" />
       <div className="fixed inset-0 overflow-y-auto">
-        <div className="flex min-h-full items-center justify-center">
+        <div
+          className="flex min-h-full justify-center"
+          style={{ alignItems: startAtTop ? 'top' : 'center' }}
+        >
           <Dialog.Panel
             className="relative max-w-3xl bg-gray-50 mx-8 rounded-md"
             style={{ width: width ? width : '100%' }}

--- a/packages/frontend/src/components/post/Post.tsx
+++ b/packages/frontend/src/components/post/Post.tsx
@@ -1,6 +1,5 @@
 import dayjs from 'dayjs';
-import { useMemo, useState } from 'react';
-import { PostWithReplies } from './PostWithReplies';
+import { useMemo } from 'react';
 import { PostProps } from '@/types/components';
 import { ReplyCount } from './ReplyCount';
 import { UserTag } from './UserTag';

--- a/packages/frontend/src/components/post/PostWithReplies.tsx
+++ b/packages/frontend/src/components/post/PostWithReplies.tsx
@@ -89,8 +89,7 @@ export const PostWithReplies = (postWithRepliesProps: PostWithRepliesProps) => {
         ) : (
           <>
             <h4>
-              {singlePost?.replies.length}{' '}
-              {singlePost?.replies.length === 1 ? 'comment' : 'comments'}
+              {singlePost?.replies.length} {singlePost?.replies.length === 1 ? 'reply' : 'replies'}
             </h4>
             <div className="flex flex-col gap-6 w-full justify-center iterms-center">
               {nestedComponentThreads}

--- a/packages/frontend/src/components/post/PostWithReplies.tsx
+++ b/packages/frontend/src/components/post/PostWithReplies.tsx
@@ -58,7 +58,7 @@ export const PostWithReplies = (postWithRepliesProps: PostWithRepliesProps) => {
   }, [singlePost]);
 
   return (
-    <Modal handleClose={handleClose}>
+    <Modal startAtTop={true} handleClose={handleClose}>
       <div className="flex flex-col gap-4 py-8 px-12 md:px-12 md:py-10">
         <div className="flex flex-col gap-3">
           <div className="flex justify-between item-center">

--- a/packages/frontend/src/components/post/PostWithReplies.tsx
+++ b/packages/frontend/src/components/post/PostWithReplies.tsx
@@ -16,7 +16,7 @@ const getPostById = async (postId: string) =>
   (await axios.get<IPostWithReplies>(`/api/v1/posts/${postId}`)).data;
 
 export const PostWithReplies = (postWithRepliesProps: PostWithRepliesProps) => {
-  const { id, timestamp, isOpen, handleClose, title, body, replyCount, userId, upvotes } =
+  const { id, timestamp, handleClose, title, body, replyCount, userId, upvotes } =
     postWithRepliesProps;
 
   const {
@@ -58,7 +58,7 @@ export const PostWithReplies = (postWithRepliesProps: PostWithRepliesProps) => {
   }, [singlePost]);
 
   return (
-    <Modal isOpen={isOpen} handleClose={handleClose}>
+    <Modal handleClose={handleClose}>
       <div className="flex flex-col gap-4 py-8 px-12 md:px-12 md:py-10">
         <div className="flex flex-col gap-3">
           <div className="flex justify-between item-center">

--- a/packages/frontend/src/components/post/PostWithReplies.tsx
+++ b/packages/frontend/src/components/post/PostWithReplies.tsx
@@ -11,6 +11,7 @@ import { Upvote } from '../Upvote';
 import { PrefixedHex } from '@personaelabs/nymjs';
 import { Modal } from '../global/Modal';
 import dayjs from 'dayjs';
+import Spinner from '../global/Spinner';
 
 const getPostById = async (postId: string) =>
   (await axios.get<IPostWithReplies>(`/api/v1/posts/${postId}`)).data;
@@ -22,6 +23,7 @@ export const PostWithReplies = (postWithRepliesProps: PostWithRepliesProps) => {
   const {
     isRefetching,
     isFetching,
+    isLoading,
     refetch,
     data: singlePost,
   } = useQuery<IPostWithReplies>({
@@ -82,12 +84,19 @@ export const PostWithReplies = (postWithRepliesProps: PostWithRepliesProps) => {
       </div>
       <div className="flex flex-col gap-8 w-full bg-gray-50 px-12 py-8">
         <PostWriter parentId={id as PrefixedHex} onSuccess={manualRefetch} />
-        <h4>
-          {singlePost?.replies.length} {singlePost?.replies.length === 1 ? 'comment' : 'comments'}
-        </h4>
-        <div className="flex flex-col gap-6 w-full justify-center iterms-center">
-          {nestedComponentThreads}
-        </div>
+        {isLoading ? (
+          <Spinner />
+        ) : (
+          <>
+            <h4>
+              {singlePost?.replies.length}{' '}
+              {singlePost?.replies.length === 1 ? 'comment' : 'comments'}
+            </h4>
+            <div className="flex flex-col gap-6 w-full justify-center iterms-center">
+              {nestedComponentThreads}
+            </div>
+          </>
+        )}
       </div>
     </Modal>
   );

--- a/packages/frontend/src/components/userInput/NewNym.tsx
+++ b/packages/frontend/src/components/userInput/NewNym.tsx
@@ -7,7 +7,6 @@ import { useSignTypedData, useAccount } from 'wagmi';
 import { ClientNym } from '@/types/components';
 
 interface NewNymProps {
-  isOpen: boolean;
   handleClose: () => void;
   nymOptions: ClientNym[];
   setNymOptions: (nymOptions: ClientNym[]) => void;
@@ -27,7 +26,7 @@ const signNym = async (nymName: string, signTypedDataAsync: any): Promise<string
 
 export const NewNym = (props: NewNymProps) => {
   const { address } = useAccount();
-  const { isOpen, handleClose, nymOptions, setNymOptions } = props;
+  const { handleClose, nymOptions, setNymOptions } = props;
   const [nymName, setnymName] = useState('');
 
   const { signTypedDataAsync } = useSignTypedData();
@@ -57,7 +56,7 @@ export const NewNym = (props: NewNymProps) => {
     handleClose();
   };
   return (
-    <Modal width="50%" isOpen={isOpen} handleClose={handleClose}>
+    <Modal width="50%" handleClose={handleClose}>
       <div className="flex flex-col gap-4 py-8 px-12 md:px-12 md:py-10">
         <div className="flex justify-start">
           <h3>Create a new nym</h3>

--- a/packages/frontend/src/components/userInput/NewNym.tsx
+++ b/packages/frontend/src/components/userInput/NewNym.tsx
@@ -47,13 +47,16 @@ export const NewNym = (props: NewNymProps) => {
   };
 
   const handleNewNym = async () => {
-    const nymSig = await signNym(nymName, signTypedDataAsync);
+    try {
+      const nymSig = await signNym(nymName, signTypedDataAsync);
+      if (nymSig) storeNym(nymSig);
 
-    if (nymSig) {
-      storeNym(nymSig);
+      setNymOptions([...nymOptions, { nymName, nymSig }]);
+      handleClose();
+    } catch (error) {
+      //TODO: error handling
+      console.error(error);
     }
-    setNymOptions([...nymOptions, { nymName, nymSig }]);
-    handleClose();
   };
   return (
     <Modal width="50%" handleClose={handleClose}>

--- a/packages/frontend/src/components/userInput/NewPost.tsx
+++ b/packages/frontend/src/components/userInput/NewPost.tsx
@@ -14,7 +14,7 @@ export const NewPost = (props: NewPostProps) => {
         <div className="flex justify-start">
           <h3>Start a discussion here</h3>
         </div>
-        <PostWriter parentId={'0x0'} onSuccess={onSuccess} />
+        <PostWriter parentId={'0x0'} onSuccess={onSuccess} handleCloseWriter={handleClose} />
       </div>
     </Modal>
   );

--- a/packages/frontend/src/components/userInput/NewPost.tsx
+++ b/packages/frontend/src/components/userInput/NewPost.tsx
@@ -2,15 +2,14 @@ import { PostWriter } from './PostWriter';
 import { Modal } from '../global/Modal';
 
 interface NewPostProps {
-  isOpen: boolean;
   handleClose: () => void;
   onSuccess: () => void;
 }
 export const NewPost = (props: NewPostProps) => {
-  const { isOpen, handleClose, onSuccess } = props;
+  const { handleClose, onSuccess } = props;
 
   return (
-    <Modal isOpen={isOpen} handleClose={handleClose}>
+    <Modal handleClose={handleClose}>
       <div className="flex flex-col gap-4 py-8 px-12 md:px-12 md:py-10">
         <div className="flex justify-start">
           <h3>Start a discussion here</h3>

--- a/packages/frontend/src/components/userInput/NymSelect.tsx
+++ b/packages/frontend/src/components/userInput/NymSelect.tsx
@@ -28,7 +28,6 @@ export const NymSelect = (props: NymSelectProps) => {
     <>
       {openNewNym ? (
         <NewNym
-          isOpen={openNewNym}
           handleClose={() => setOpenNewNym(false)}
           nymOptions={nymOptions}
           setNymOptions={setNymOptions}

--- a/packages/frontend/src/components/userInput/NymSelect.tsx
+++ b/packages/frontend/src/components/userInput/NymSelect.tsx
@@ -1,7 +1,7 @@
 import { faAngleDown, faAngleUp, faCheck, faPlus } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import Image from 'next/image';
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { NewNym } from './NewNym';
 import { ClientNym } from '@/types/components';
 import { useAccount } from 'wagmi';
@@ -19,10 +19,24 @@ const getNymOptions = (address: string | undefined) => {
 export const NymSelect = (props: NymSelectProps) => {
   const { address } = useAccount();
   const { selectedNym, setSelectedNym } = props;
+  const divRef = useRef<HTMLDivElement>(null);
 
   const [openSelect, setOpenSelect] = useState<boolean>(false);
   const [openNewNym, setOpenNewNym] = useState<boolean>(false);
   const [nymOptions, setNymOptions] = useState<ClientNym[]>(getNymOptions(address));
+
+  //TODO: make this outclick event work for nym select modal
+  useEffect(() => {
+    const handleOutsideClick = (event: MouseEvent) => {
+      if (divRef.current && !divRef.current.contains(event.target as Node)) {
+        setOpenSelect(false);
+      }
+    };
+    document.addEventListener('click', handleOutsideClick);
+    return () => {
+      document.removeEventListener('click', handleOutsideClick);
+    };
+  }, []);
 
   return (
     <>
@@ -34,7 +48,7 @@ export const NymSelect = (props: NymSelectProps) => {
         />
       ) : null}
       <p className="secondary">Posting as</p>
-      <div className="relative w-max">
+      <div className="relative w-max" ref={divRef}>
         <div
           className="bg-white flex gap-2 border items-center border-gray-200 rounded-xl px-2 py-2.5 cursor-pointer"
           onClick={() => setOpenSelect(!openSelect)}

--- a/packages/frontend/src/components/userInput/PostWriter.tsx
+++ b/packages/frontend/src/components/userInput/PostWriter.tsx
@@ -22,6 +22,7 @@ export const PostWriter = ({ parentId, handleCloseWriter, onSuccess }: IWriterPr
   const [showWalletWarning, setShowWalletWarning] = useState<boolean>(false);
   const [nym, setNym] = useState<ClientNym>({ nymSig: '0x0', nymName: 'Doxed' });
   const { address } = useAccount();
+  const { signTypedDataAsync } = useSignTypedData();
 
   // TODO
   const someDbQuery = useMemo(() => true, []);
@@ -29,20 +30,29 @@ export const PostWriter = ({ parentId, handleCloseWriter, onSuccess }: IWriterPr
   // TODO
   const canPost = useMemo(() => true, []);
 
-  const { signTypedDataAsync } = useSignTypedData();
+  const resetWriter = () => {
+    onSuccess();
+    if (handleCloseWriter) handleCloseWriter();
+    setPostMsg('');
+    setTitleMsg('');
+  };
 
   const sendPost = async () => {
     if (!address) {
       setShowWalletWarning(true);
       return;
     }
-    if (nym.nymName === 'Doxed') {
-      await postDoxed({ title, body, parentId }, signTypedDataAsync);
-    } else {
-      await postPseudo(nym.nymName, nym.nymSig, { title, body, parentId }, signTypedDataAsync);
+    try {
+      if (nym.nymName === 'Doxed') {
+        await postDoxed({ title, body, parentId }, signTypedDataAsync);
+      } else {
+        await postPseudo(nym.nymName, nym.nymSig, { title, body, parentId }, signTypedDataAsync);
+      }
+      resetWriter();
+    } catch (error) {
+      //TODO: error handling
+      console.error(error);
     }
-    onSuccess ? onSuccess() : null;
-    if (handleCloseWriter) handleCloseWriter();
   };
 
   return (

--- a/packages/frontend/src/components/userInput/PostWriter.tsx
+++ b/packages/frontend/src/components/userInput/PostWriter.tsx
@@ -48,11 +48,7 @@ export const PostWriter = ({ parentId, handleCloseWriter, onSuccess }: IWriterPr
   return (
     <>
       {showWalletWarning ? (
-        <WalletWarning
-          isOpen={showWalletWarning}
-          handleClose={() => setShowWalletWarning(false)}
-          action="comment"
-        />
+        <WalletWarning handleClose={() => setShowWalletWarning(false)} action="comment" />
       ) : null}
       {someDbQuery === undefined ? (
         <div className="bg-gray-100 border border-gray-300 p-12 py-24 rounded-md flex justify-center text-gray-800">

--- a/packages/frontend/src/pages/users/[userId].tsx
+++ b/packages/frontend/src/pages/users/[userId].tsx
@@ -19,6 +19,7 @@ export default function User() {
   const router = useRouter();
   const userId = router.query.userId as string;
   const isDoxed = userId && isAddress(userId);
+  console.log({ isDoxed }, !!isDoxed);
 
   // determine if post creator or replied to post (does post have a parent ID)
   const { isLoading: postsLoading, data: userPosts } = useQuery<IUserPost[]>({
@@ -42,6 +43,7 @@ export default function User() {
     () => userPosts?.find((p) => p.id === openPostId),
     [openPostId, userPosts],
   );
+  console.log(upvotesLoading);
 
   return (
     <>
@@ -61,18 +63,21 @@ export default function User() {
               {userId && <UserTag userId={userId} />}
               <div className="flex flex-col gap-8 max-w-3xl mx-auto py-5 md:py-10 px-3 md:px-0">
                 <h4>Posts</h4>
-                {userPosts ? (
+
+                {postsLoading ? (
+                  <Spinner />
+                ) : userPosts ? (
                   userPosts.map((post) => (
                     <Post key={post.id} {...post} handleOpenPost={() => setOpenPostId(post.id)} />
                   ))
-                ) : (
-                  <Spinner />
-                )}
-                {/* Ugly code but will only show upvotes if user is doxed. */}
+                ) : null}
+                {/* TODO: Ugly code to only render upvotes when doxed */}
                 {isDoxed ? (
                   <>
                     <h4>Upvotes</h4>
-                    {userUpvotes ? (
+                    {upvotesLoading ? (
+                      <Spinner />
+                    ) : userUpvotes ? (
                       userUpvotes.map((vote) => (
                         <Post
                           key={vote.post.id}
@@ -80,9 +85,7 @@ export default function User() {
                           handleOpenPost={() => setOpenPostId(vote.post.id)}
                         />
                       ))
-                    ) : (
-                      <Spinner />
-                    )}
+                    ) : null}
                   </>
                 ) : null}
               </div>

--- a/packages/frontend/src/pages/users/[userId].tsx
+++ b/packages/frontend/src/pages/users/[userId].tsx
@@ -42,9 +42,7 @@ export default function User() {
 
   return (
     <>
-      {openPost ? (
-        <PostWithReplies {...openPost} isOpen={true} handleClose={() => setOpenPostId('')} />
-      ) : null}
+      {openPost ? <PostWithReplies {...openPost} handleClose={() => setOpenPostId('')} /> : null}
       <main className="flex w-full flex-col justify-center items-center">
         <div className="w-full bg-gray-50 flex flex-col justify-center items-center">
           <div className="bg-black dots w-full">

--- a/packages/frontend/types/components/index.ts
+++ b/packages/frontend/types/components/index.ts
@@ -2,11 +2,10 @@ import { PrefixedHex } from '@personaelabs/nymjs';
 import { IRootPost } from '../api';
 
 export type PostProps = IRootPost & {
-  handleOpenPost?: () => void;
+  handleOpenPost: () => void;
 };
 
 export type PostWithRepliesProps = IRootPost & {
-  isOpen: boolean;
   handleClose: () => void;
 };
 


### PR DESCRIPTION
- [x] Remove redundant `isOpen` prop from modals and conditionally render all Modals instead
- [x] Position `PostWithReplies` modal at the top of the viewport
- [x] Separate `Header.tsx` from `Posts.tsx`
- [x] Close modals on successful action (new nym creation, upvote, new post)
- [x] Added try catch blocks to all HTTP requests (error handling still a to-do)