### PR TITLE
Add a warning in the nym sig message

### DIFF
--- a/packages/frontend/src/components/example/PostMessage.tsx
+++ b/packages/frontend/src/components/example/PostMessage.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { NYM_CODE_TYPE, DOMAIN, PrefixedHex } from '@personaelabs/nymjs';
+import { NYM_CODE_TYPE, DOMAIN, PrefixedHex, NYM_CODE_WARNING } from '@personaelabs/nymjs';
 import { useSignTypedData, useAccount } from 'wagmi';
 import { ContentUserInput } from '@/types/components';
 import { postDoxed, postPseudo } from '@/lib/actions';
@@ -29,7 +29,8 @@ const ExamplePost = () => {
     domain: DOMAIN,
     types: NYM_CODE_TYPE,
     message: {
-      nymName,
+      nymName: nymName,
+      warning: NYM_CODE_WARNING,
     },
   });
 

--- a/packages/frontend/src/components/userInput/NewNym.tsx
+++ b/packages/frontend/src/components/userInput/NewNym.tsx
@@ -2,7 +2,7 @@ import Image from 'next/image';
 import { Modal } from '../global/Modal';
 import { useState } from 'react';
 import { MainButton } from '../MainButton';
-import { NYM_CODE_TYPE, DOMAIN } from '@personaelabs/nymjs';
+import { NYM_CODE_TYPE, DOMAIN, NYM_CODE_WARNING } from '@personaelabs/nymjs';
 import { useSignTypedData, useAccount } from 'wagmi';
 import { ClientNym } from '@/types/components';
 
@@ -20,6 +20,7 @@ const signNym = async (nymName: string, signTypedDataAsync: any): Promise<string
     types: NYM_CODE_TYPE,
     message: {
       nymName,
+      warning: NYM_CODE_WARNING,
     },
   });
   return nymSig as string;

--- a/packages/nymjs/src/core/prover.ts
+++ b/packages/nymjs/src/core/prover.ts
@@ -16,6 +16,7 @@ import {
   computeNymHash,
   serializePublicInput,
   serializeNymAttestation,
+  toTypedNymName,
 } from '../utils';
 import { EIP712TypedData } from '../types';
 import { MerkleProof } from '@personaelabs/spartan-ecdsa';
@@ -55,13 +56,7 @@ export class NymProver extends Profiler {
     contentSigStr: string,
     membershipProof: MerkleProof,
   ): Promise<Buffer> {
-    const typedNymName: EIP712TypedData = {
-      domain: DOMAIN,
-      types: NYM_CODE_TYPE,
-      value: {
-        nymName,
-      },
-    };
+    const typedNymName = toTypedNymName(nymName);
     const nymSig = computeEffECDSASig(nymSigStr, typedNymName);
 
     const typedContentMessage: EIP712TypedData = {

--- a/packages/nymjs/src/types.ts
+++ b/packages/nymjs/src/types.ts
@@ -100,7 +100,7 @@ export const DOMAIN: EIP712Domain = {
   salt: '0x1f62937a3189e37c79aea1c4a1fcd5a56395069b1f973cc4d2218c3b65a6c9ff',
 };
 
-export const NYM_CODE_WARNING = 'Please make sure the url is `nymz.xyz`';
+export const NYM_CODE_WARNING = 'Please make sure the url is `nymz.xyz`. Leaking this signature can leak your anonymity.';
 
 export const NYM_CODE_TYPE = {
   Nym: [

--- a/packages/nymjs/src/types.ts
+++ b/packages/nymjs/src/types.ts
@@ -100,8 +100,16 @@ export const DOMAIN: EIP712Domain = {
   salt: '0x1f62937a3189e37c79aea1c4a1fcd5a56395069b1f973cc4d2218c3b65a6c9ff',
 };
 
+export const NYM_CODE_WARNING = 'Please make sure the url is `nymz.xyz`';
+
 export const NYM_CODE_TYPE = {
-  Nym: [{ name: 'nymName', type: 'string' }],
+  Nym: [
+    { name: 'nymName', type: 'string' },
+    {
+      name: 'warning',
+      type: 'string',
+    },
+  ],
 };
 
 export const CONTENT_MESSAGE_TYPES = {

--- a/packages/nymjs/src/utils.ts
+++ b/packages/nymjs/src/utils.ts
@@ -15,6 +15,7 @@ import {
   Upvote,
   PrefixedHex,
   Content,
+  NYM_CODE_WARNING,
 } from './types';
 import { _TypedDataEncoder } from 'ethers/lib/utils';
 import { ecrecover, fromRpcSig, pubToAddress } from '@ethereumjs/util';
@@ -271,7 +272,7 @@ export const deserializeNymAttestation = (
 export const toTypedNymName = (nymName: string): EIP712TypedData => ({
   domain: DOMAIN,
   types: NYM_CODE_TYPE,
-  value: { nymName },
+  value: { nymName, warning: NYM_CODE_WARNING },
 });
 
 export const toTypedContent = (content: Content): EIP712TypedData => ({


### PR DESCRIPTION
Add a warning to the message which yields the nym sig.

- The domain `nymz.xyz` is temporary; we can change it after getting the actual domain.
- Not the prettiest UX, but I'm not sure if we can do any better. Lmk if you have any suggestions! (especially the wording of the warning message; we should warn users properly but don't wanna scare them).


<img width="1239" alt="Screenshot 2023-05-17 at 12 45 09" src="https://github.com/personaelabs/nym/assets/36762093/48418d2d-4406-4175-9af2-ab69c4433094">


