### PR TITLE
Nym Selection Improvements

### DIFF
--- a/packages/frontend/src/components/global/UserAvatar.tsx
+++ b/packages/frontend/src/components/global/UserAvatar.tsx
@@ -36,6 +36,7 @@ export const UserAvatar = (props: UserAvatarProps) => {
   }, [userId]);
   return (
     <div
+      className="shrink-0"
       style={{ borderRadius: '50%', overflow: 'hidden', width: width, height: width }}
       ref={svgRef}
       dangerouslySetInnerHTML={{ __html: avatar }}

--- a/packages/frontend/src/components/global/UserAvatar.tsx
+++ b/packages/frontend/src/components/global/UserAvatar.tsx
@@ -1,0 +1,44 @@
+import { getSeedFromHash } from '@/lib/avatar-utils';
+import { NOUNS_AVATAR_RANGES } from '@/lib/constants';
+import { ImageData, getNounData } from '@nouns/assets';
+import { PNGCollectionEncoder, buildSVG } from '@nouns/sdk';
+import { useEffect, useMemo, useRef } from 'react';
+
+const encoder = new PNGCollectionEncoder(ImageData.palette);
+
+interface UserAvatarProps {
+  userId: string;
+  width: number;
+}
+
+export const UserAvatar = (props: UserAvatarProps) => {
+  const { userId, width } = props;
+  const svgRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const scaleSVG = () => {
+      if (svgRef.current) {
+        const svgElement = svgRef.current.children[0];
+
+        svgElement.setAttribute('width', width.toString());
+        svgElement.setAttribute('height', width.toString());
+      }
+    };
+    scaleSVG();
+  });
+
+  const avatar = useMemo(() => {
+    const seedFromUserId = getSeedFromHash(userId, 5, NOUNS_AVATAR_RANGES);
+    const { parts, background } = getNounData(seedFromUserId);
+    const svg = buildSVG(parts, encoder.data.palette, background);
+
+    return svg;
+  }, [userId]);
+  return (
+    <div
+      style={{ borderRadius: '50%', overflow: 'hidden', width: width, height: width }}
+      ref={svgRef}
+      dangerouslySetInnerHTML={{ __html: avatar }}
+    />
+  );
+};

--- a/packages/frontend/src/components/post/UserTag.tsx
+++ b/packages/frontend/src/components/post/UserTag.tsx
@@ -1,20 +1,13 @@
-import { getNounData, ImageData } from '@nouns/assets';
-import { buildSVG, PNGCollectionEncoder } from '@nouns/sdk';
-import { useEffect, useMemo, useRef } from 'react';
-import { getSeedFromHash } from '../../lib/avatar-utils';
-import { NOUNS_AVATAR_RANGES } from '../../lib/constants';
 import { useAccount, useEnsName } from 'wagmi';
 import { isAddress } from 'viem';
 import Link from 'next/link';
+import { UserAvatar } from '../global/UserAvatar';
 
 interface UserTagProps {
   imgURL?: string;
   userId: string;
   date?: string;
 }
-
-const encoder = new PNGCollectionEncoder(ImageData.palette);
-
 export const UserTag = (props: UserTagProps) => {
   const { userId, date } = props;
   const isDoxed = isAddress(userId);
@@ -25,36 +18,11 @@ export const UserTag = (props: UserTagProps) => {
     enabled: isDoxed,
   });
 
-  const svgRef = useRef<HTMLDivElement>(null);
-
-  useEffect(() => {
-    const scaleSVG = () => {
-      if (svgRef.current) {
-        const svgElement = svgRef.current.children[0];
-
-        svgElement.setAttribute('width', '30');
-        svgElement.setAttribute('height', '30');
-      }
-    };
-    scaleSVG();
-  });
-  const avatar = useMemo(() => {
-    const seedFromUserId = getSeedFromHash(userId, 5, NOUNS_AVATAR_RANGES);
-    const { parts, background } = getNounData(seedFromUserId);
-    const svg = buildSVG(parts, encoder.data.palette, background);
-
-    return svg;
-  }, [userId]);
-
   return (
     // stop post modal from opening on click of user page link
     <div className="flex gap-2 items-center" onClick={(e) => e.stopPropagation()}>
       <Link href={`/users/${userId}`} className="flex gap-2 justify-center items-center">
-        <div
-          style={{ borderRadius: '50%', overflow: 'hidden' }}
-          ref={svgRef}
-          dangerouslySetInnerHTML={{ __html: avatar }}
-        />
+        <UserAvatar userId={userId} width={30} />
         {isDoxed ? (
           data ? (
             <p className="font-semibold">{data}</p>

--- a/packages/frontend/src/components/post/UserTag.tsx
+++ b/packages/frontend/src/components/post/UserTag.tsx
@@ -35,9 +35,8 @@ export const UserTag = (props: UserTagProps) => {
       </Link>
       {date && (
         <>
-          {' '}
           <p className="secondary">-</p>
-          <p className="secondary">{date}</p>
+          <p className="secondary whitespace-nowrap">{date}</p>
         </>
       )}
     </div>

--- a/packages/frontend/src/components/userInput/NewNym.tsx
+++ b/packages/frontend/src/components/userInput/NewNym.tsx
@@ -26,10 +26,21 @@ const signNym = async (nymName: string, signTypedDataAsync: any): Promise<string
   return nymSig as string;
 };
 
+const generateRandomString = (length: number) => {
+  let string = '';
+  const chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+  let i = 0;
+  while (i < length) {
+    string += chars.charAt(Math.floor(Math.random() * chars.length));
+    i += 1;
+  }
+  return string;
+};
+
 export const NewNym = (props: NewNymProps) => {
   const { address } = useAccount();
   const { handleClose, nymOptions, setNymOptions, setSelectedNym } = props;
-  const [nymName, setnymName] = useState('');
+  const [nymName, setNymName] = useState('');
 
   const { signTypedDataAsync } = useSignTypedData();
 
@@ -62,7 +73,7 @@ export const NewNym = (props: NewNymProps) => {
     }
   };
   return (
-    <Modal width="50%" handleClose={handleClose}>
+    <Modal width="60%" handleClose={handleClose}>
       <div className="flex flex-col gap-4 py-8 px-12 md:px-12 md:py-10">
         <div className="flex justify-start">
           <h3>Create a new nym</h3>
@@ -78,9 +89,15 @@ export const NewNym = (props: NewNymProps) => {
               type="text"
               placeholder="Name"
               value={nymName}
-              onChange={(event) => setnymName(event.target.value)}
+              onChange={(event) => setNymName(event.target.value)}
             />
           </div>
+          <button
+            className="secondary underline"
+            onClick={() => setNymName(generateRandomString(5))}
+          >
+            Generate random name
+          </button>
         </div>
         <div className="flex justify-center">
           <MainButton

--- a/packages/frontend/src/components/userInput/NewNym.tsx
+++ b/packages/frontend/src/components/userInput/NewNym.tsx
@@ -10,6 +10,7 @@ interface NewNymProps {
   handleClose: () => void;
   nymOptions: ClientNym[];
   setNymOptions: (nymOptions: ClientNym[]) => void;
+  setSelectedNym: (selectedNym: ClientNym) => void;
 }
 
 const signNym = async (nymName: string, signTypedDataAsync: any): Promise<string> => {
@@ -27,7 +28,7 @@ const signNym = async (nymName: string, signTypedDataAsync: any): Promise<string
 
 export const NewNym = (props: NewNymProps) => {
   const { address } = useAccount();
-  const { handleClose, nymOptions, setNymOptions } = props;
+  const { handleClose, nymOptions, setNymOptions, setSelectedNym } = props;
   const [nymName, setnymName] = useState('');
 
   const { signTypedDataAsync } = useSignTypedData();
@@ -51,8 +52,9 @@ export const NewNym = (props: NewNymProps) => {
     try {
       const nymSig = await signNym(nymName, signTypedDataAsync);
       if (nymSig) storeNym(nymSig);
-
-      setNymOptions([...nymOptions, { nymName, nymSig }]);
+      const newNym = { nymName, nymSig };
+      setNymOptions([...nymOptions, newNym]);
+      setSelectedNym(newNym);
       handleClose();
     } catch (error) {
       //TODO: error handling
@@ -79,7 +81,6 @@ export const NewNym = (props: NewNymProps) => {
               onChange={(event) => setnymName(event.target.value)}
             />
           </div>
-          <p className="secondary">#0000</p>
         </div>
         <div className="flex justify-center">
           <MainButton

--- a/packages/frontend/src/components/userInput/NymSelect.tsx
+++ b/packages/frontend/src/components/userInput/NymSelect.tsx
@@ -1,6 +1,5 @@
 import { faAngleDown, faAngleUp, faCheck, faPlus } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import Image from 'next/image';
 import { useEffect, useRef, useState } from 'react';
 import { NewNym } from './NewNym';
 import { ClientNym } from '@/types/components';
@@ -26,6 +25,7 @@ export const NymSelect = (props: NymSelectProps) => {
   const [openSelect, setOpenSelect] = useState<boolean>(false);
   const [openNewNym, setOpenNewNym] = useState<boolean>(false);
   const [nymOptions, setNymOptions] = useState<ClientNym[]>(getNymOptions(address, doxed));
+  const [maxSelectHeight, setMaxSelectHeight] = useState<number>(0);
 
   //TODO: make this outclick event work for nym select modal
   useEffect(() => {
@@ -34,7 +34,13 @@ export const NymSelect = (props: NymSelectProps) => {
         setOpenSelect(false);
       }
     };
-    document.addEventListener('click', handleOutsideClick);
+
+    if (divRef.current) {
+      const { bottom } = divRef.current.getBoundingClientRect();
+      setMaxSelectHeight(window.innerHeight - bottom - 30);
+      document.addEventListener('click', handleOutsideClick);
+    }
+
     return () => {
       document.removeEventListener('click', handleOutsideClick);
     };
@@ -53,41 +59,48 @@ export const NymSelect = (props: NymSelectProps) => {
         />
       ) : null}
       <p className="secondary">Posting as</p>
-      <div className="relative w-max" ref={divRef}>
+      <div className="relative w-[30%]" ref={divRef}>
         <div
-          className="bg-white flex gap-2 border items-center border-gray-200 rounded-xl px-2 py-2.5 cursor-pointer"
+          className="bg-white flex gap-2 justify-between border items-center border-gray-200 rounded-xl px-2 py-2.5 cursor-pointer"
           onClick={() => setOpenSelect(!openSelect)}
         >
-          <UserAvatar userId={address} width={20} />
-          <p>
-            {selectedNym.nymName === address
-              ? selectedNym.nymName.slice(0, 5) + '...'
-              : selectedNym.nymName}
-          </p>
+          <div className="flex gap-2" style={{ width: 'calc(100% - 18px)' }}>
+            <UserAvatar userId={address} width={20} />
+            <p className="overflow-hidden text-ellipsis whitespace-nowrap">{selectedNym.nymName}</p>
+          </div>
           <FontAwesomeIcon icon={openSelect ? faAngleUp : faAngleDown} />
         </div>
         {openSelect ? (
-          <div className="w-max absolute top-full right-0 w-full bg-white mt-2 border items-center border-gray-200 rounded-xl cursor-pointer">
+          <div
+            className="w-full absolute top-full left-0 bg-white mt-2 border border-gray-200 rounded-xl cursor-pointer"
+            style={{ maxHeight: maxSelectHeight, overflow: 'scroll' }}
+          >
             {nymOptions &&
               nymOptions.map((nym) => (
                 <div
                   key={nym.nymSig}
-                  className="flex justify-between gap-2 items-center px-2 py-2.5 rounded-xl hover:bg-gray-100"
+                  className="w-full flex justify-between gap-2 items-center px-2 py-2.5 rounded-xl hover:bg-gray-100"
                   onClick={() => {
                     setSelectedNym(nym);
                     setOpenSelect(false);
                   }}
                 >
-                  <div className="flex gap-2 justify-start">
+                  <div className="w-full flex justify-between gap-2">
                     {/* TODO: get avatar using correct userId (need access to nymHash) */}
-                    <UserAvatar userId={address} width={20} />
-                    <p>{nym.nymName === address ? nym.nymName.slice(0, 5) + '...' : nym.nymName}</p>
+                    <div className="flex gap-2" style={{ width: 'calc(100% - 18px)' }}>
+                      <UserAvatar userId={address} width={20} />
+                      <p className="shrink overflow-hidden text-ellipsis whitespace-nowrap">
+                        {nym.nymName}
+                      </p>
+                    </div>
+                    <FontAwesomeIcon
+                      icon={faCheck}
+                      color={'#0E76FD'}
+                      className={`shrink-0 ${
+                        nym.nymSig === selectedNym.nymSig ? 'opacity-1' : 'opacity-0'
+                      }`}
+                    />
                   </div>
-                  <FontAwesomeIcon
-                    icon={faCheck}
-                    color={'#0E76FD'}
-                    className={`${nym.nymSig === selectedNym.nymSig ? 'opacity-1' : 'opacity-0'}`}
-                  />
                 </div>
               ))}
             <div

--- a/packages/frontend/src/components/userInput/NymSelect.tsx
+++ b/packages/frontend/src/components/userInput/NymSelect.tsx
@@ -20,12 +20,16 @@ export const NymSelect = (props: NymSelectProps) => {
   const { address, selectedNym, setSelectedNym } = props;
   const divRef = useRef<HTMLDivElement>(null);
 
-  const doxed = { nymSig: '0x0', nymName: address };
+  const doxed = { nymSig: '0x0', nymHash: '', nymName: address };
 
   const [openSelect, setOpenSelect] = useState<boolean>(false);
   const [openNewNym, setOpenNewNym] = useState<boolean>(false);
   const [nymOptions, setNymOptions] = useState<ClientNym[]>(getNymOptions(address, doxed));
   const [maxSelectHeight, setMaxSelectHeight] = useState<number>(0);
+
+  const getUserId = (nym: ClientNym): string => {
+    return nym.nymName === address ? address : `${nym.nymName}-${nym.nymHash}`;
+  };
 
   //TODO: make this outclick event work for nym select modal
   useEffect(() => {
@@ -50,6 +54,7 @@ export const NymSelect = (props: NymSelectProps) => {
     <>
       {openNewNym ? (
         <NewNym
+          address={address}
           handleClose={() => {
             setOpenNewNym(false), setOpenSelect(false);
           }}
@@ -65,7 +70,7 @@ export const NymSelect = (props: NymSelectProps) => {
           onClick={() => setOpenSelect(!openSelect)}
         >
           <div className="flex gap-2" style={{ width: 'calc(100% - 18px)' }}>
-            <UserAvatar userId={address} width={20} />
+            <UserAvatar userId={getUserId(selectedNym)} width={20} />
             <p className="overflow-hidden text-ellipsis whitespace-nowrap">{selectedNym.nymName}</p>
           </div>
           <FontAwesomeIcon icon={openSelect ? faAngleUp : faAngleDown} />
@@ -86,9 +91,8 @@ export const NymSelect = (props: NymSelectProps) => {
                   }}
                 >
                   <div className="w-full flex justify-between gap-2">
-                    {/* TODO: get avatar using correct userId (need access to nymHash) */}
                     <div className="flex gap-2" style={{ width: 'calc(100% - 18px)' }}>
-                      <UserAvatar userId={address} width={20} />
+                      <UserAvatar userId={getUserId(nym)} width={20} />
                       <p className="shrink overflow-hidden text-ellipsis whitespace-nowrap">
                         {nym.nymName}
                       </p>

--- a/packages/frontend/src/components/userInput/NymSelect.tsx
+++ b/packages/frontend/src/components/userInput/NymSelect.tsx
@@ -21,7 +21,7 @@ export const NymSelect = (props: NymSelectProps) => {
   const { address, selectedNym, setSelectedNym } = props;
   const divRef = useRef<HTMLDivElement>(null);
 
-  const doxed = { nymSig: '0x0', nymName: address.slice(0, 5) };
+  const doxed = { nymSig: '0x0', nymName: address };
 
   const [openSelect, setOpenSelect] = useState<boolean>(false);
   const [openNewNym, setOpenNewNym] = useState<boolean>(false);
@@ -59,11 +59,15 @@ export const NymSelect = (props: NymSelectProps) => {
           onClick={() => setOpenSelect(!openSelect)}
         >
           <UserAvatar userId={address} width={20} />
-          <p>{selectedNym.nymName ? selectedNym.nymName : doxed.nymName}</p>
+          <p>
+            {selectedNym.nymName === address
+              ? selectedNym.nymName.slice(0, 5) + '...'
+              : selectedNym.nymName}
+          </p>
           <FontAwesomeIcon icon={openSelect ? faAngleUp : faAngleDown} />
         </div>
         {openSelect ? (
-          <div className="w-max absolute top-full left-0 w-full bg-white mt-2 border items-center border-gray-200 rounded-xl cursor-pointer">
+          <div className="w-max absolute top-full right-0 w-full bg-white mt-2 border items-center border-gray-200 rounded-xl cursor-pointer">
             {nymOptions &&
               nymOptions.map((nym) => (
                 <div
@@ -77,7 +81,7 @@ export const NymSelect = (props: NymSelectProps) => {
                   <div className="flex gap-2 justify-start">
                     {/* TODO: get avatar using correct userId (need access to nymHash) */}
                     <UserAvatar userId={address} width={20} />
-                    <p>{nym.nymName}</p>
+                    <p>{nym.nymName === address ? nym.nymName.slice(0, 5) + '...' : nym.nymName}</p>
                   </div>
                   <FontAwesomeIcon
                     icon={faCheck}

--- a/packages/frontend/src/components/userInput/PostWriter.tsx
+++ b/packages/frontend/src/components/userInput/PostWriter.tsx
@@ -20,7 +20,7 @@ export const PostWriter = ({ parentId, handleCloseWriter, onSuccess }: IWriterPr
   const [body, setPostMsg] = useState<string>('');
   const [title, setTitleMsg] = useState<string>('');
   const [showWalletWarning, setShowWalletWarning] = useState<boolean>(false);
-  const [nym, setNym] = useState<ClientNym>({ nymSig: '0x0', nymName: 'Doxed' });
+  const [nym, setNym] = useState<ClientNym>({ nymSig: '0x0', nymName: '' });
   const { address } = useAccount();
   const { signTypedDataAsync } = useSignTypedData();
 
@@ -87,7 +87,9 @@ export const PostWriter = ({ parentId, handleCloseWriter, onSuccess }: IWriterPr
             </div>
           </div>
           <div className="w-full flex gap-2 items-center justify-end text-gray-500">
-            {address ? <NymSelect selectedNym={nym} setSelectedNym={setNym} /> : null}
+            {address ? (
+              <NymSelect address={address} selectedNym={nym} setSelectedNym={setNym} />
+            ) : null}
             <MainButton color="black" handler={sendPost} loading={false} message={'Send'} />
           </div>
         </div>

--- a/packages/frontend/src/components/userInput/PostWriter.tsx
+++ b/packages/frontend/src/components/userInput/PostWriter.tsx
@@ -20,8 +20,8 @@ export const PostWriter = ({ parentId, handleCloseWriter, onSuccess }: IWriterPr
   const [body, setPostMsg] = useState<string>('');
   const [title, setTitleMsg] = useState<string>('');
   const [showWalletWarning, setShowWalletWarning] = useState<boolean>(false);
-  const [nym, setNym] = useState<ClientNym>({ nymSig: '0x0', nymName: '' });
   const { address } = useAccount();
+  const [nym, setNym] = useState<ClientNym>({ nymSig: '0x0', nymName: address as string });
   const { signTypedDataAsync } = useSignTypedData();
 
   // TODO
@@ -43,7 +43,7 @@ export const PostWriter = ({ parentId, handleCloseWriter, onSuccess }: IWriterPr
       return;
     }
     try {
-      if (nym.nymName === 'Doxed') {
+      if (nym.nymName === address) {
         await postDoxed({ title, body, parentId }, signTypedDataAsync);
       } else {
         await postPseudo(nym.nymName, nym.nymSig, { title, body, parentId }, signTypedDataAsync);

--- a/packages/frontend/src/components/userInput/PostWriter.tsx
+++ b/packages/frontend/src/components/userInput/PostWriter.tsx
@@ -21,7 +21,11 @@ export const PostWriter = ({ parentId, handleCloseWriter, onSuccess }: IWriterPr
   const [title, setTitleMsg] = useState<string>('');
   const [showWalletWarning, setShowWalletWarning] = useState<boolean>(false);
   const { address } = useAccount();
-  const [nym, setNym] = useState<ClientNym>({ nymSig: '0x0', nymName: address as string });
+  const [nym, setNym] = useState<ClientNym>({
+    nymSig: '0x0',
+    nymHash: '',
+    nymName: address as string,
+  });
   const { signTypedDataAsync } = useSignTypedData();
 
   // TODO

--- a/packages/frontend/types/components/index.ts
+++ b/packages/frontend/types/components/index.ts
@@ -12,6 +12,7 @@ export type PostWithRepliesProps = IRootPost & {
 export type ClientNym = {
   nymName: string;
   nymSig: string;
+  nymHash: string;
 };
 
 export type ClientUpvote = {


### PR DESCRIPTION
Closes #105 

- [x] Option to generate a random nym name (current just generates a random string of 5 characters)
- [x] Show avatar in the dropdown when choosing which nym to use
> - [x] Show avatar for doxed user in selection panel
> - [x] Show avatar for nym in selection panel 
- [x] Remove #0000 from panel.
- [x] When making a new nym, have that new nym be auto selected for a post.

To Do:
- [x] Handle long nym names -- overflow with ellipsis
<img width="385" alt="Screenshot 2023-05-18 at 2 46 36 PM" src="https://github.com/personaelabs/nym/assets/95446735/3ee9e72d-2e18-492e-badf-9e304202bfe8">

- [x] Handle long list of nyms -- overflow scroll when it hits the bottom of the viewport