### PR TITLE
Fix avatar collisions by handling addresses and nyms separately

### DIFF
--- a/packages/frontend/src/lib/avatar-utils.ts
+++ b/packages/frontend/src/lib/avatar-utils.ts
@@ -1,4 +1,5 @@
 import MersenneTwister from 'mersenne-twister';
+import { isAddress } from 'viem';
 
 // generate count random numbers from a hash within each respective range
 function generateRandomNumbersFromHash(hash: string, count: number, ranges: number[]): number[] {
@@ -14,7 +15,7 @@ function generateRandomNumbersFromHash(hash: string, count: number, ranges: numb
   // within range to actually produce meaningful random numbers.
   let seed;
   // if it's an address
-  if (hash.startsWith('0x')) {
+  if (isAddress(hash)) {
     seed = Number(parseInt(hash, 16).toString().substring(0, 12)) * 10000000000000000000000;
   } else {
     // if it's a nym we need to remove the nym code prefix

--- a/packages/frontend/src/lib/avatar-utils.ts
+++ b/packages/frontend/src/lib/avatar-utils.ts
@@ -1,5 +1,4 @@
 import MersenneTwister from 'mersenne-twister';
-import { NOUNS_AVATAR_RANGES } from './constants';
 
 // generate count random numbers from a hash within each respective range
 function generateRandomNumbersFromHash(hash: string, count: number, ranges: number[]): number[] {

--- a/packages/frontend/src/lib/avatar-utils.ts
+++ b/packages/frontend/src/lib/avatar-utils.ts
@@ -1,4 +1,5 @@
 import MersenneTwister from 'mersenne-twister';
+import { NOUNS_AVATAR_RANGES } from './constants';
 
 // generate count random numbers from a hash within each respective range
 function generateRandomNumbersFromHash(hash: string, count: number, ranges: number[]): number[] {
@@ -12,7 +13,16 @@ function generateRandomNumbersFromHash(hash: string, count: number, ranges: numb
   // with sufficiently large numbers the generated random numbers end up being the same. So
   // tl;dr we do this to get fairly unqiue deterministic seed for a given userId that is
   // within range to actually produce meaningful random numbers.
-  const seed = Number(parseInt(hash, 16).toString().substring(0, 12)) * 1000000;
+  let seed;
+  // if it's an address
+  if (hash.startsWith('0x')) {
+    seed = Number(parseInt(hash, 16).toString().substring(0, 12)) * 10000000000000000000000;
+  } else {
+    // if it's a nym we need to remove the nym code prefix
+    seed =
+      Number(parseInt(hash.split('-')[1], 16).toString().substring(0, 12)) *
+      10000000000000000000000;
+  }
 
   // Create a Mersenne Twister PRNG instance with the seed
   const mt = new MersenneTwister(seed);


### PR DESCRIPTION
This fixes a bug which caused collisions to occur with nyms because we were not correctly checking if the `userId` (which is just a hex value) or a nym machine readable code (where we need to remove the nym prefix to get to the hex string).