### PR TITLE
Add column `address` to `TreeNode`

### DIFF
--- a/packages/db/prisma/migrations/20230520191158_add_column_address/migration.sql
+++ b/packages/db/prisma/migrations/20230520191158_add_column_address/migration.sql
@@ -1,0 +1,11 @@
+/*
+  Warnings:
+
+  - Added the required column `address` to the `TreeNode` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE "TreeNode" ADD COLUMN     "address" TEXT NOT NULL;
+
+ALTER TABLE  "TreeNode"
+ADD CONSTRAINT "address_missing_hex_prefix" CHECK ("address" ~ '^0x.*');

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -12,6 +12,7 @@ datasource db {
 
 model TreeNode {
   pubkey    String
+  address   String
   type      GroupType
   path      String[]
   indices   String[]

--- a/packages/frontend/src/pages/api/v1/groups/latest.ts
+++ b/packages/frontend/src/pages/api/v1/groups/latest.ts
@@ -15,6 +15,7 @@ const handleGetLatestGroup = async (req: NextApiRequest, res: NextApiResponse) =
 
   const treeNodes = await prisma.treeNode.findMany({
     select: {
+      address: true,
       pubkey: true,
       path: true,
       indices: true,

--- a/packages/merkle_tree/src/writeTree.ts
+++ b/packages/merkle_tree/src/writeTree.ts
@@ -304,6 +304,7 @@ async function writeTree(blockHeight: number) {
         const index = anonSet1Tree.indexOf(anonSet1PubKeyHashes[i]);
         const merkleProof = anonSet1Tree.createProof(index);
         return {
+          address: account.address,
           pubkey: account.pubKey,
           path: merkleProof.siblings.map(s => BigInt(s).toString(16)),
           indices: merkleProof.pathIndices.map(i => i.toString()),
@@ -335,6 +336,7 @@ async function writeTree(blockHeight: number) {
         const index = anonSet2Tree.indexOf(anonSet2PubKeyHashes[i]);
         const merkleProof = anonSet2Tree.createProof(index);
         return {
+          address: account.address,
           pubkey: account.pubKey,
           path: merkleProof.siblings.map(s => BigInt(s).toString(16)),
           indices: merkleProof.pathIndices.map(i => i.toString()),

--- a/packages/test_data/scripts/populateTestData.ts
+++ b/packages/test_data/scripts/populateTestData.ts
@@ -315,6 +315,7 @@ const populateTestData = async () => {
     data: PRIV_KEYS.map((privKey, i) => {
       const merkleProof = tree.createProof(tree.indexOf(pubKeyHashes[i]));
       return {
+        address: `0x${privateToAddress(privKey).toString('hex')}`,
         pubkey: `0x${privateToPublic(privKey).toString('hex')}`,
         path: merkleProof.siblings.map((sibling) => `${sibling.toString()}`),
         indices: merkleProof.pathIndices.map((index) => index.toString()),


### PR DESCRIPTION
Add an `address` column to `TreeNode`.

### How to test

- First, delete all rows in the `TreeNode` table. (This is necessary because we’re adding a non-null column)
- Run `pnpm -F db migrate:dev` to add the column
- Run `pnpm test_data:populate` to update re-populate the test data

@cha0sg0d  To check if an address is in a group, you can use the [GET groups/latest endpoint](https://github.com/personaelabs/nym/blob/2cb51c4f85e5d2c9b21b45b31e2734ba16db56d1/packages/frontend/src/pages/api/v1/groups/latest.ts#L6) to get all members in a group, and check the inclusion it in the frontend!

(We don't wanna have an endpoint that takes an address and returns true/false re the inclusion, because that'll break pseudonymity.)