### PR TITLE
[READY FOR REVIEW] Remove outline on user tag when post is clicked

### DIFF
--- a/packages/frontend/src/components/post/UserTag.tsx
+++ b/packages/frontend/src/components/post/UserTag.tsx
@@ -24,7 +24,11 @@ export const UserTag = (props: UserTagProps) => {
   return (
     // stop post modal from opening on click of user page link
     <div className="flex gap-2 items-center" onClick={(e) => e.stopPropagation()}>
-      <Link href={`/users/${userId}`} className="flex gap-2 justify-center items-center">
+      <Link
+        style={{ outline: 'none' }}
+        href={`/users/${userId}`}
+        className="flex gap-2 justify-center items-center"
+      >
         <UserAvatar userId={userId} width={30} />
         {isDoxed ? (
           data ? (


### PR DESCRIPTION
Fixes a small UI bug where the user tag is outline when a post is clicked
Before:
![Screenshot 2023-05-23 at 9 52 14 AM](https://github.com/personaelabs/nym/assets/7995105/ae35ec62-97df-4d41-800a-d01199637e9a)



After:
![Screenshot 2023-05-23 at 9 56 03 AM](https://github.com/personaelabs/nym/assets/7995105/14371840-9d85-4797-9723-32525fae4107)
