### PR TITLE
Add ENS addresses to test data group

### DIFF
--- a/packages/test_data/scripts/populateTestData.ts
+++ b/packages/test_data/scripts/populateTestData.ts
@@ -15,7 +15,13 @@ import {
   GroupType,
 } from '@prisma/client';
 import testData, { TestData } from './testData';
-import { ecsign, privateToAddress, privateToPublic, toCompactSig } from '@ethereumjs/util';
+import {
+  ecsign,
+  privateToAddress,
+  privateToPublic,
+  pubToAddress,
+  toCompactSig,
+} from '@ethereumjs/util';
 import {
   AttestationScheme,
   Content,
@@ -54,6 +60,37 @@ const log = (msg: string) => {
   process.stdout.write(`${msg}`);
 };
 
+const DEV_PUBKEYS = [
+  // personaelabs.eth
+  '37c6ebdcb07fe1e007aa748a9368fd96961aeceb291c2183541d1a5b8c1ba65349000a7a69d17576f1fa65d728741f6e4b9dba9465073b1f99ec185c060a5f74',
+  // cha0sg0d.eth
+  '2e1869b4aa4611eff68043fb8bfecf9e58a6252cf3de6547167099a3124345c0372b2a0edc636444c0718b53c76da503e3619e82bb4f0e2e34cbc02a84ad18d3',
+  // amirbolous.eth
+  '3ba0d5397de63df8884014d446fd68318345f236cfe3f808ae879dedb471fdb2673e0be282cbf9a422333c36afa2b5e6dc815bbb40e9cd0dc7df5179759d1383',
+  // dantehrani.eth
+  '765b012d6340fd3baf3068e3e118a68a559b832af2d9ddd05585fedcf9f9c2a95a65f71708281d9e1517e28c3643fa932d7675a233d8cc4edc3440c10684cd95',
+].map((pubKey) => Buffer.from(pubKey, 'hex'));
+
+const DEV_ADDRESSES = [
+  // personaelabs.eth
+  '141b63D93DaF55bfb7F396eEe6114F3A5d4A90B2',
+  // cha0sg0d.eth
+  '3ff4EcB0D7A01235dcCD9fc59B0d4969Cb011032',
+  // amirbolous.eth
+  '926B47C42Ce6BC92242c080CF8fAFEd34a164017',
+  // dantehrani.eth
+  '400EA6522867456E988235675b9Cb5b1Cf5b79C8',
+];
+
+// Sanity check
+for (let i = 0; i < DEV_PUBKEYS.length; i++) {
+  const pubKey = DEV_PUBKEYS[i];
+  const address = DEV_ADDRESSES[i].toLowerCase();
+  if (pubToAddress(pubKey).toString('hex') !== address) {
+    throw new Error(`Public key ${pubKey.toString('hex')} doesn't match the address ${address}`);
+  }
+}
+
 const populateTestData = async () => {
   // ##############################
   // Create accounts.
@@ -80,11 +117,18 @@ const populateTestData = async () => {
   await poseidon.initWasm();
   const tree = new Tree(20, poseidon);
 
+  // Get the public key hashes of the signers
   const pubKeyHashes = PRIV_KEYS.map((privKey) => {
     return poseidon.hashPubKey(privateToPublic(privKey));
   });
 
-  for (let i = 0; i < PRIV_KEYS.length; i++) {
+  // Get the public key hashes of the dev accounts
+  for (let i = 0; i < DEV_PUBKEYS.length; i++) {
+    pubKeyHashes.push(poseidon.hashPubKey(DEV_PUBKEYS[i]));
+  }
+
+  // Insert all public key hashes into the tree
+  for (let i = 0; i < pubKeyHashes.length; i++) {
     tree.insert(pubKeyHashes[i]);
   }
 
@@ -311,8 +355,9 @@ const populateTestData = async () => {
   // Only the tree nodes of a single tree can exist in our database,
   // so we delete all existing trees nodes to store a new set of tree nodes.
   await prisma.treeNode.deleteMany({});
-  await prisma.treeNode.createMany({
-    data: PRIV_KEYS.map((privKey, i) => {
+
+  const treeNodes = [
+    ...PRIV_KEYS.map((privKey, i) => {
       const merkleProof = tree.createProof(tree.indexOf(pubKeyHashes[i]));
       return {
         address: `0x${privateToAddress(privKey).toString('hex')}`,
@@ -322,6 +367,21 @@ const populateTestData = async () => {
         type: GroupType.OneNoun,
       };
     }),
+
+    ...DEV_PUBKEYS.map((pubKey, i) => {
+      const merkleProof = tree.createProof(tree.indexOf(pubKeyHashes[PRIV_KEYS.length + i]));
+      return {
+        address: `0x${pubToAddress(pubKey).toString('hex')}`,
+        pubkey: `0x${pubKey.toString('hex')}`,
+        path: merkleProof.siblings.map((sibling) => `${sibling.toString()}`),
+        indices: merkleProof.pathIndices.map((index) => index.toString()),
+        type: GroupType.OneNoun,
+      };
+    }),
+  ];
+
+  await prisma.treeNode.createMany({
+    data: treeNodes,
   });
 
   log('...done!\n\n');


### PR DESCRIPTION
I ran the test data population script from my local env targeting the staging db, so we should now be able to submit posts/upvotes with our ENS in staging.

(Nothing will happen upon merging this PR)