### PR TITLE
Add depth count to `Post`

### DIFF
--- a/packages/db/prisma/migrations/20230525132316_add_column_depth/migration.sql
+++ b/packages/db/prisma/migrations/20230525132316_add_column_depth/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - Added the required column `depth` to the `Post` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE "Post" ADD COLUMN     "depth" INTEGER NOT NULL;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -78,6 +78,7 @@ model Post {
   userId            String // Nym or ETH address
   hashScheme        HashScheme
   attestationScheme AttestationScheme
+  depth             Int
   createdAt         DateTime          @default(now())
   updatedAt         DateTime          @updatedAt
 }

--- a/packages/frontend/src/lib/errors.ts
+++ b/packages/frontend/src/lib/errors.ts
@@ -4,3 +4,4 @@ export const INVALID_TIMESTAMP = 'Invalid timestamp!';
 export const INVALID_SIGNATURE = 'Invalid signature!';
 export const USER_NOT_IN_LATEST_GROUP = 'Public key not in latest group';
 export const ALREADY_UPVOTED = 'Already upvoted';
+export const PARENT_NOT_FOUND = 'Parent not found';

--- a/packages/frontend/src/pages/api/v1/utils.ts
+++ b/packages/frontend/src/pages/api/v1/utils.ts
@@ -31,6 +31,28 @@ export const getNymFromAttestation = (attestation: Buffer): string => {
   return nym;
 };
 
+export const getPostDepthFromParent = async (parentId: string): Promise<number> => {
+  if (parentId === '0x0') {
+    return 0;
+  }
+
+  const parent = await prisma.post.findFirst({
+    select: {
+      depth: true,
+    },
+    where: {
+      id: parentId,
+    },
+  });
+
+  if (!parent) {
+    // Here we assume that the parent exists, so if it doesn't, throw an error.
+    throw new Error(`Parent not found in getPostDepthFromParent. parentId: ${parentId})`);
+  }
+
+  return parent.depth + 1;
+};
+
 export const findPost = async (
   postId: string,
 ): Promise<{

--- a/packages/test_data/scripts/populateTestData.ts
+++ b/packages/test_data/scripts/populateTestData.ts
@@ -155,6 +155,7 @@ const populateTestData = async () => {
     accountIndex: number,
     parentId: string | null,
     rootId: string | null,
+    depth: number,
     attestationScheme: AttestationScheme,
   ): Promise<PostExt> => {
     const privKey = PRIV_KEYS[accountIndex];
@@ -219,6 +220,7 @@ const populateTestData = async () => {
         updatedAt: new Date(),
         userId: nym,
         upvotes,
+        depth,
       };
     } else {
       const post = toPost(content, contentSigStr, AttestationScheme.EIP712);
@@ -239,6 +241,7 @@ const populateTestData = async () => {
         createdAt: new Date(),
         updatedAt: new Date(),
         upvotes,
+        depth,
       };
     }
   };
@@ -247,6 +250,7 @@ const populateTestData = async () => {
   const createPostWithReplies = async (
     rootId: string | null,
     parentId: string | null,
+    depth: number,
     data: TestData,
     isRoot: boolean,
   ): Promise<PostExt[]> => {
@@ -259,6 +263,7 @@ const populateTestData = async () => {
       accountIndex,
       parentId,
       rootId,
+      depth,
       data.attestationScheme,
     );
 
@@ -267,6 +272,7 @@ const populateTestData = async () => {
         createPostWithReplies(
           isRoot ? (post.id as PrefixedHex) : rootId,
           post.id as PrefixedHex,
+          depth + 1,
           reply,
           false,
         ),
@@ -280,7 +286,7 @@ const populateTestData = async () => {
   for (let i = 0; i < testData.length; i++) {
     const data = testData[i];
 
-    allPosts.push(...(await createPostWithReplies(null, null, data, true)));
+    allPosts.push(...(await createPostWithReplies(null, null, 0, data, true)));
   }
   log('...done\n');
 


### PR DESCRIPTION
Add column `depth` to `Post`.

On staging, I deleted all `Post` records (and `Upvote` due to foreign key relation) and ran the migration, adding the `depth` column. Also re-populated the staging db with test data.