### PR TITLE
Fix proving bug

### DIFF
--- a/packages/frontend/src/components/userInput/NameSelect.tsx
+++ b/packages/frontend/src/components/userInput/NameSelect.tsx
@@ -46,6 +46,12 @@ export const NameSelect = (props: NameSelectProps) => {
     } else return '';
   };
 
+  useEffect(() => {
+    if (address) {
+      setNymOptions(getNymOptions(address));
+    }
+  }, [address]);
+
   //TODO: make this outclick event work for nym select modal
   useEffect(() => {
     setSelectedName(nymOptions.length > 0 ? nymOptions[0] : null);


### PR DESCRIPTION
Refresh `nymOptions` when the address changes so the content is signed with the same account as the selected nym.

After implementing this fix, I haven't encountered the proof generation issue, but there could be other causes, so let's keep an eye on proof generation failures.

Closes #130 ( we think )