### PR TITLE
Improve proving

### DIFF
--- a/packages/circuits/package.json
+++ b/packages/circuits/package.json
@@ -14,7 +14,7 @@
   },
   "devDependencies": {
     "@ethereumjs/util": "^8.0.5",
-    "@personaelabs/spartan-ecdsa": "^2.1.3",
+    "@personaelabs/spartan-ecdsa": "^2.1.4",
     "@wagmi/core": "^0.10.8",
     "circom_tester": "^0.0.19",
     "ethers": "5",

--- a/packages/circuits/tests/nym_ownership.test.ts
+++ b/packages/circuits/tests/nym_ownership.test.ts
@@ -96,7 +96,7 @@ maybe('nym ownership', () => {
       contentSigS: bytesToBigInt(contentSig.s),
 
       // Merkle proof
-      siblings: merkleProof.siblings,
+      siblings: merkleProof.siblings.map((sibling) => sibling[0]),
       pathIndices: merkleProof.pathIndices,
       root: tree.root(),
     };

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -21,7 +21,7 @@
     "@nouns/assets": "^0.4.2",
     "@nouns/sdk": "^0.4.0",
     "@personaelabs/nymjs": "*",
-    "@personaelabs/spartan-ecdsa": "^2.1.3",
+    "@personaelabs/spartan-ecdsa": "^2.1.4",
     "@prisma/client": "4.5.0",
     "@rainbow-me/rainbowkit": "1.0.0",
     "@sentry/integrations": "^7.53.1",

--- a/packages/frontend/src/components/example/PostMessage.tsx
+++ b/packages/frontend/src/components/example/PostMessage.tsx
@@ -4,6 +4,7 @@ import { useSignTypedData } from 'wagmi';
 import { ContentUserInput } from '@/types/components';
 import { postDoxed, postPseudo } from '@/lib/actions';
 import useAccount from '@/hooks/useAccount';
+import useProver from '@/hooks/useProver';
 
 const ExamplePost = () => {
   const { address, valid, error } = useAccount();
@@ -12,6 +13,7 @@ const ExamplePost = () => {
   useEffect(() => {
     setHydrated(true);
   }, []);
+  const prover = useProver();
 
   const [nymName, setnymName] = useState<string>('');
   const [doxedContentInput, setDoxedContentInput] = useState<ContentUserInput>({
@@ -108,7 +110,7 @@ const ExamplePost = () => {
           />
           <button
             className="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded disabled:opacity-50 disabled:cursor-not-allowed mt-4"
-            onClick={() => postPseudo(nymName, nymSig, nymContentInput, signTypedDataAsync)}
+            onClick={() => postPseudo(prover, nymName, nymSig, nymContentInput, signTypedDataAsync)}
             disabled={!nymSig ? true : false}
           >
             Submit a pseudonymous post

--- a/packages/frontend/src/components/userInput/PostWriter.tsx
+++ b/packages/frontend/src/components/userInput/PostWriter.tsx
@@ -12,6 +12,7 @@ import { Modal } from '../global/Modal';
 import { RetryError } from '../global/RetryError';
 import useError from '@/hooks/useError';
 import { UserContext } from '@/pages/_app';
+import useProver from '@/hooks/useProver';
 
 interface IWriterProps {
   parentId: PrefixedHex;
@@ -32,6 +33,9 @@ export const PostWriter = ({ parentId, handleCloseWriter, onSuccess }: IWriterPr
   const [name, setName] = useState<ClientName | null>(null);
   const { signTypedDataAsync } = useSignTypedData();
   const signedHandler = () => setHasSignedPost(true);
+  const prover = useProver({
+    enableProfiler: true,
+  });
 
   // TODO
   const someDbQuery = useMemo(() => true, []);
@@ -62,6 +66,7 @@ export const PostWriter = ({ parentId, handleCloseWriter, onSuccess }: IWriterPr
           result = await postDoxed({ title, body, parentId }, signTypedDataAsync, signedHandler);
         } else if (name.type === NameType.PSEUDO && name.name) {
           result = await postPseudo(
+            prover,
             name.name,
             name.nymSig,
             { title, body, parentId },

--- a/packages/frontend/src/hooks/useProver.ts
+++ b/packages/frontend/src/hooks/useProver.ts
@@ -1,0 +1,19 @@
+import { useMemo, useEffect } from 'react';
+import { NymProver, ProverConfig } from '@personaelabs/nymjs';
+
+const useProver = (proverConfig?: ProverConfig) => {
+  const prover = useMemo(() => new NymProver(proverConfig || {}), [proverConfig]);
+
+  // Fetch the circuit and initialize the WASM
+  // as soon as the page renders to improve perceived proving speed
+  useEffect(() => {
+    (async () => {
+      await prover.loadCircuit();
+      await prover.initWasm();
+    })();
+  }, [prover]);
+
+  return prover;
+};
+
+export default useProver;

--- a/packages/frontend/src/lib/actions.ts
+++ b/packages/frontend/src/lib/actions.ts
@@ -84,7 +84,7 @@ export const postPseudo = async (
 
     const merkleProof: MerkleProof = {
       pathIndices: userMerkleProof?.indices,
-      siblings: userMerkleProof?.path.map((sibling) => BigInt(sibling)),
+      siblings: userMerkleProof?.path.map((sibling) => [BigInt(sibling)]),
       root: BigInt(group.root),
     };
 

--- a/packages/frontend/src/lib/actions.ts
+++ b/packages/frontend/src/lib/actions.ts
@@ -62,6 +62,7 @@ export const postDoxed = async (
 };
 
 export const postPseudo = async (
+  nymProver: NymProver,
   nymName: string,
   nymSig: any,
   nymContentInput: ContentUserInput,
@@ -107,13 +108,6 @@ export const postPseudo = async (
 
     // Call handler once user has signed the post
     if (onSigned) onSigned();
-
-    // Setup the prover
-    const nymProver = new NymProver({
-      enableProfiler: true,
-    });
-
-    await nymProver.initWasm();
 
     // Generate the proof
     const attestation = await nymProver.prove(

--- a/packages/frontend/test/api.test.ts
+++ b/packages/frontend/test/api.test.ts
@@ -75,7 +75,7 @@ const mockFindTreeNodeOnce = (_merkleProof: MerkleProof) => {
     type: 'OneNoun',
     createdAt: new Date(),
     indices: _merkleProof.pathIndices.map((i) => i.toString()),
-    path: _merkleProof.siblings.map((s) => `0x${s.toString(16)}`),
+    path: _merkleProof.siblings.map((s) => `0x${s[0].toString(16)}`),
   });
 };
 

--- a/packages/merkle_tree/package.json
+++ b/packages/merkle_tree/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@ethereumjs/tx": "^4.1.1",
     "@ethereumjs/util": "^8.0.5",
-    "@personaelabs/spartan-ecdsa": "^2.1.3",
+    "@personaelabs/spartan-ecdsa": "^2.1.4",
     "@prisma/client": "4.5.0",
     "alchemy-sdk": "^2.6.1",
     "async-lock": "1.4.0",

--- a/packages/nymjs/package.json
+++ b/packages/nymjs/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "@ethereumjs/util": "^8.0.5",
-    "@personaelabs/spartan-ecdsa": "^2.1.3",
+    "@personaelabs/spartan-ecdsa": "^2.1.4",
     "circomlibjs": "^0.1.7",
     "ethers": "^5",
     "snarkjs": "0.5.0"

--- a/packages/nymjs/src/core/prover.ts
+++ b/packages/nymjs/src/core/prover.ts
@@ -59,7 +59,7 @@ export class NymProver extends Profiler {
     }
   }
 
-  private verifyMerkleProf(proof: MerkleProof, pubKeyHash: bigint) {
+  private verifyMerkleProof(proof: MerkleProof, pubKeyHash: bigint) {
     const treeDepth = 20;
     const tree = new Tree(treeDepth, this.poseidon);
     if (!tree.verifyProof(proof, pubKeyHash)) {
@@ -115,7 +115,7 @@ export class NymProver extends Profiler {
       throw new Error(INCONSISTENT_SIGNERS(nymSigAddr, contentSigAddr));
     }
 
-    this.verifyMerkleProf(membershipProof, this.poseidon.hashPubKey(nymSigPubKey));
+    this.verifyMerkleProof(membershipProof, this.poseidon.hashPubKey(nymSigPubKey));
 
     const nymHash = bufferToBigInt(Buffer.from(await computeNymHash(nymSigStr), 'hex'));
 

--- a/packages/nymjs/src/errors.ts
+++ b/packages/nymjs/src/errors.ts
@@ -1,0 +1,9 @@
+import { PrefixedHex } from './types';
+
+export const INCONSISTENT_SIGNERS = (
+  nymSigner: PrefixedHex,
+  contentSinger: PrefixedHex,
+): string => {
+  return `Signer of the nym (${nymSigner}) does not match the signer of the content (${contentSinger})`;
+};
+export const INVALID_MERKLE_PROOF = 'Invalid Merkle proof';

--- a/packages/nymjs/src/utils.ts
+++ b/packages/nymjs/src/utils.ts
@@ -394,3 +394,7 @@ export const recoverUpvotePubkey = (upvote: Upvote): string => {
 
   return `0x${pubKey.toString('hex')}`;
 };
+
+export const pubToPrefixedAddress = (pubKey: Buffer): PrefixedHex => {
+  return `0x${pubToAddress(pubKey).toString('hex')}`;
+};

--- a/packages/nymjs/src/utils.ts
+++ b/packages/nymjs/src/utils.ts
@@ -18,7 +18,7 @@ import {
   NYM_CODE_WARNING,
 } from './types';
 import { _TypedDataEncoder } from 'ethers/lib/utils';
-import { ecrecover, fromRpcSig, pubToAddress } from '@ethereumjs/util';
+import { PrefixedHexString, ecrecover, fromRpcSig, pubToAddress } from '@ethereumjs/util';
 import { computeEffEcdsaPubInput } from '@personaelabs/spartan-ecdsa';
 import { EIP712TypedData, EffECDSASig, Post, PublicInput, NymProofAuxiliary } from './types';
 import wasm, { init } from './wasm';
@@ -80,7 +80,15 @@ export const bigIntToLeBytes = (n: bigint, size: number): Uint8Array => {
   return bytes.reverse();
 };
 
-export const bigIntToPrefixedHex = (val: bigint): PrefixedHex => `0x${val.toString(16)}`;
+export const bigIntToPrefixedHex = (val: bigint): PrefixedHex => {
+  const hex = val.toString(16);
+  return `0x${hex.padStart(64, '0')}`;
+};
+
+export const bigIntToHex = (val: bigint): string => {
+  const hex = val.toString(16);
+  return hex.padStart(64, '0');
+};
 
 // Borrowing from: https://github.com/personaelabs/heyanoun/blob/main/frontend/utils/utils.ts#L83
 export function eip712MsgHash(
@@ -169,9 +177,9 @@ async function poseidonHash(inputs: bigint[]): Promise<bigint> {
 }
 
 // Compute nymHash = Poseidon([nymSig.s, nymSig.s])
-export async function computeNymHash(nymSig: string): Promise<string> {
+export async function computeNymHash(nymSig: string): Promise<PrefixedHexString> {
   const nymSigS = bufferToBigInt(fromRpcSig(nymSig).s);
-  return (await poseidonHash([nymSigS, nymSigS])).toString(16);
+  return bigIntToHex(await poseidonHash([nymSigS, nymSigS]));
 }
 
 export const serializePublicInput = (publicInput: PublicInput): Buffer => {

--- a/packages/test_data/package.json
+++ b/packages/test_data/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "@ethereumjs/util": "^8.0.5",
     "@personaelabs/nymjs": "*",
-    "@personaelabs/spartan-ecdsa": "^2.1.3",
+    "@personaelabs/spartan-ecdsa": "^2.1.4",
     "@prisma/client": "4.5.0",
     "prisma": "4.5.0",
     "dotenv": "^16.0.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,8 +42,8 @@ importers:
         specifier: ^8.0.5
         version: 8.0.5
       '@personaelabs/spartan-ecdsa':
-        specifier: ^2.1.3
-        version: 2.1.3
+        specifier: ^2.1.4
+        version: 2.1.4
       '@wagmi/core':
         specifier: ^0.10.8
         version: 0.10.8(@types/node@18.15.3)(ethers@5.7.2)(react@18.2.0)(typescript@5.0.4)
@@ -99,8 +99,8 @@ importers:
         specifier: '*'
         version: link:../nymjs
       '@personaelabs/spartan-ecdsa':
-        specifier: ^2.1.3
-        version: 2.1.3
+        specifier: ^2.1.4
+        version: 2.1.4
       '@prisma/client':
         specifier: 4.5.0
         version: 4.5.0(prisma@4.5.0)
@@ -238,8 +238,8 @@ importers:
         specifier: ^8.0.5
         version: 8.0.5
       '@personaelabs/spartan-ecdsa':
-        specifier: ^2.1.3
-        version: 2.1.3
+        specifier: ^2.1.4
+        version: 2.1.4
       '@prisma/client':
         specifier: 4.5.0
         version: 4.5.0(prisma@4.5.0)
@@ -317,8 +317,8 @@ importers:
         specifier: ^8.0.5
         version: 8.0.5
       '@personaelabs/spartan-ecdsa':
-        specifier: ^2.1.3
-        version: 2.1.3
+        specifier: ^2.1.4
+        version: 2.1.4
       circomlibjs:
         specifier: ^0.1.7
         version: 0.1.7
@@ -348,8 +348,8 @@ importers:
         specifier: '*'
         version: link:../nymjs
       '@personaelabs/spartan-ecdsa':
-        specifier: ^2.1.3
-        version: 2.1.3
+        specifier: ^2.1.4
+        version: 2.1.4
       '@prisma/client':
         specifier: 4.5.0
         version: 4.5.0(prisma@4.5.0)
@@ -486,7 +486,7 @@ packages:
       '@babel/traverse': 7.21.5(supports-color@5.5.0)
       '@babel/types': 7.21.5
       convert-source-map: 1.9.0
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@5.5.0)
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.0
@@ -568,7 +568,7 @@ packages:
       '@babel/core': 7.21.8
       '@babel/helper-compilation-targets': 7.21.5(@babel/core@7.21.8)
       '@babel/helper-plugin-utils': 7.21.5
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@5.5.0)
       lodash.debounce: 4.0.8
       resolve: 1.22.2
       semver: 6.3.0
@@ -2141,7 +2141,7 @@ packages:
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dependencies:
       ajv: 6.12.6
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@5.5.0)
       espree: 9.5.2
       globals: 13.20.0
       ignore: 5.2.4
@@ -3585,7 +3585,7 @@ packages:
     engines: {node: '>=10.10.0'}
     dependencies:
       '@humanwhocodes/object-schema': 1.2.1
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@5.5.0)
       minimatch: 3.1.2
     transitivePeerDependencies:
       - supports-color
@@ -3957,7 +3957,7 @@ packages:
     engines: {node: '>=14.0.0'}
     dependencies:
       '@types/debug': 4.1.7
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@5.5.0)
       semver: 7.5.0
       superstruct: 1.0.3
     transitivePeerDependencies:
@@ -4262,8 +4262,8 @@ packages:
       - utf-8-validate
     dev: false
 
-  /@personaelabs/spartan-ecdsa@2.1.3:
-    resolution: {integrity: sha512-yVNEKbm1DqM17qjsVIV+8z1SJm2J0S+Rflk1jrrVSa/2J+Hce6FpfXumvMXU+U+HoZyXTwW2+qloOgZGRNQAoA==}
+  /@personaelabs/spartan-ecdsa@2.1.4:
+    resolution: {integrity: sha512-nqArRr1m5bjQOKKPaf+tSumfQ8sfIH021fhsmsy8epccp95/gM955VsgUSNSHcLTddHPrO5lI14oDOsXALPGYQ==}
     dependencies:
       '@ethereumjs/util': 8.0.6
       '@zk-kit/incremental-merkle-tree': 1.0.0
@@ -5567,7 +5567,7 @@ packages:
       '@typescript-eslint/scope-manager': 5.55.0
       '@typescript-eslint/type-utils': 5.55.0(eslint@8.38.0)(typescript@5.0.4)
       '@typescript-eslint/utils': 5.55.0(eslint@8.38.0)(typescript@5.0.4)
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@5.5.0)
       eslint: 8.38.0
       grapheme-splitter: 1.0.4
       ignore: 5.2.4
@@ -5592,7 +5592,7 @@ packages:
       '@typescript-eslint/scope-manager': 5.55.0
       '@typescript-eslint/types': 5.55.0
       '@typescript-eslint/typescript-estree': 5.55.0(typescript@5.0.4)
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@5.5.0)
       eslint: 8.38.0
       typescript: 5.0.4
     transitivePeerDependencies:
@@ -5619,7 +5619,7 @@ packages:
     dependencies:
       '@typescript-eslint/typescript-estree': 5.55.0(typescript@5.0.4)
       '@typescript-eslint/utils': 5.55.0(eslint@8.38.0)(typescript@5.0.4)
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@5.5.0)
       eslint: 8.38.0
       tsutils: 3.21.0(typescript@5.0.4)
       typescript: 5.0.4
@@ -5643,7 +5643,7 @@ packages:
     dependencies:
       '@typescript-eslint/types': 5.55.0
       '@typescript-eslint/visitor-keys': 5.55.0
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@5.5.0)
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.5.0
@@ -6750,7 +6750,7 @@ packages:
     resolution: {integrity: sha512-7Epl1Blf4Sy37j4v9f9FjICCh4+KAQOyXgHEwlyBiAQLbhKdq/i2QQU3amQalS/wPhdPzDXPL5DMR5bkn+YeWg==}
     engines: {node: '>= 8.0.0'}
     dependencies:
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@5.5.0)
       depd: 2.0.0
       humanize-ms: 1.2.1
     transitivePeerDependencies:
@@ -8606,6 +8606,7 @@ packages:
     dependencies:
       ms: 2.1.2
       supports-color: 8.1.1
+    dev: true
 
   /decamelize-keys@1.1.1:
     resolution: {integrity: sha512-WiPxgEirIV0/eIOMcnFBA3/IJZAZqKnwAwWyvvdi4lsr1WCN22nhdf/3db3DoZcUjTV2SqfzIwNyp6y2xs3nmg==}
@@ -9235,7 +9236,7 @@ packages:
       eslint: '*'
       eslint-plugin-import: '*'
     dependencies:
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@5.5.0)
       enhanced-resolve: 5.14.0
       eslint: 8.38.0
       eslint-module-utils: 2.8.0(@typescript-eslint/parser@5.55.0)(eslint-import-resolver-node@0.3.7)(eslint-import-resolver-typescript@3.5.5)(eslint@8.38.0)
@@ -9422,7 +9423,7 @@ packages:
       ajv: 6.12.6
       chalk: 4.1.2
       cross-spawn: 7.0.3
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@5.5.0)
       doctrine: 3.0.0
       escape-string-regexp: 4.0.0
       eslint-scope: 7.2.0
@@ -11286,7 +11287,7 @@ packages:
     resolution: {integrity: sha512-n3s8EwkdFIJCG3BPKBYvskgXGoy88ARzvegkitk60NxRdwltLOTaH7CUiMRXvwYorl0Q712iEjcWB+fK/MrWVw==}
     engines: {node: '>=10'}
     dependencies:
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@5.5.0)
       istanbul-lib-coverage: 3.2.0
       source-map: 0.6.1
     transitivePeerDependencies:
@@ -12161,7 +12162,7 @@ packages:
       chalk: 5.2.0
       cli-truncate: 3.1.0
       commander: 10.0.1
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@5.5.0)
       execa: 7.1.1
       lilconfig: 2.1.0
       listr2: 5.0.8
@@ -15822,7 +15823,7 @@ packages:
     dependencies:
       component-emitter: 1.3.0
       cookiejar: 2.1.4
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@5.5.0)
       fast-safe-stringify: 2.1.1
       form-data: 4.0.0
       formidable: 2.1.2
@@ -15868,6 +15869,7 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       has-flag: 4.0.0
+    dev: true
 
   /supports-preserve-symlinks-flag@1.0.0:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}


### PR DESCRIPTION
Improvements
- Throw an error when **1. the signer of the nymSig and contentSig are different 2. the Merkle proof is invalid.** This is better than the errors the circuit throws (which only indicates which constraint failed) for debugging.
- Expose a `loadCircuit` from `NymProver` so the frontend can fetch the circuit as soon as the page renders, which improves perceived proving time. I implement this improvement with the custom hook [useProver](https://github.com/personaelabs/nym/blob/dan/improve-proving/packages/frontend/src/hooks/useProver.ts).


Notable changes
- I updated spartan-ecdsa to expose the `verifyProof` from the `Tree` class. We use the method to verify the Merkle proof in`NymProver`.