### PR TITLE
Mobile Responsiveness

### DIFF
--- a/packages/frontend/src/components/ConnectWallet.tsx
+++ b/packages/frontend/src/components/ConnectWallet.tsx
@@ -4,7 +4,7 @@ import { ConnectButton } from '@rainbow-me/rainbowkit';
 export default function ConnectWallet() {
   return (
     <WalletProvider>
-      <ConnectButton />
+      <ConnectButton chainStatus={'none'} accountStatus={'address'} showBalance={false} />
     </WalletProvider>
   );
 }

--- a/packages/frontend/src/components/Header.tsx
+++ b/packages/frontend/src/components/Header.tsx
@@ -5,27 +5,30 @@ import Image from 'next/image';
 import { useContext } from 'react';
 import { UserContext } from '@/pages/_app';
 import { UserContextType } from '@/types/components';
+import { useAccount } from 'wagmi';
 
 export const Header = () => {
-  const { isMobile } = useContext(UserContext) as UserContextType;
+  const { address } = useAccount();
+  const { isMobile, isValid } = useContext(UserContext) as UserContextType;
+
   return (
     <div className="bg-black dots w-full">
-      <div className="flex flex-col gap-2 py-3 md:pt-6 md:pb-0">
-        <nav className="w-full px-3 md:px-6 flex justify-between items-center">
-          <a className="flex gap-2 items-center" href={'/'}>
+      <div className="flex flex-col gap-2 py-4 md:pt-6 md:pb-0">
+        <nav className="w-full px-4 md:px-6 flex justify-between items-center">
+          <a className="min-w-0 flex shrink gap-2 items-center" href={'/'}>
             <div>
               <div className="w-[35px] md:w-auto">
                 <Image src={logo} alt="logo" />
               </div>
             </div>
-            {isMobile ? (
-              <h4 className="text-white">PseudoNym</h4>
-            ) : (
-              <h3 className="text-white">PseudoNym</h3>
-            )}
+            <p
+              className={`text-white font-semibold breakText ${isMobile ? 'text-lg' : 'text-2xl'}`}
+            >
+              PseudoNym
+            </p>
           </a>
           <div className="flex gap-2 items-center">
-            {!isMobile && <ConnectWallet />}
+            {(!isMobile || !address || !isValid) && <ConnectWallet />}
             <MyProfile />
           </div>
         </nav>

--- a/packages/frontend/src/components/Header.tsx
+++ b/packages/frontend/src/components/Header.tsx
@@ -6,7 +6,7 @@ import Image from 'next/image';
 export const Header = () => {
   return (
     <div className="bg-black dots w-full">
-      <div className="flex flex-col gap-2 pt-8">
+      <div className="flex flex-col gap-2 pt-6">
         <nav className="w-full px-6 flex justify-between items-center">
           <a className="flex gap-2 items-center" href={'/'}>
             <div>

--- a/packages/frontend/src/components/Header.tsx
+++ b/packages/frontend/src/components/Header.tsx
@@ -2,27 +2,39 @@ import ConnectWallet from './ConnectWallet';
 import logo from '../../public/logo.svg';
 import { MyProfile } from './MyProfile';
 import Image from 'next/image';
+import { useContext } from 'react';
+import { UserContext } from '@/pages/_app';
+import { UserContextType } from '@/types/components';
 
 export const Header = () => {
+  const { isMobile } = useContext(UserContext) as UserContextType;
   return (
     <div className="bg-black dots w-full">
-      <div className="flex flex-col gap-2 pt-6">
-        <nav className="w-full px-6 flex justify-between items-center">
+      <div className="flex flex-col gap-2 py-3 md:pt-6 md:pb-0">
+        <nav className="w-full px-3 md:px-6 flex justify-between items-center">
           <a className="flex gap-2 items-center" href={'/'}>
             <div>
-              <Image src={logo} alt="logo" />
+              <div className="w-[35px] md:w-auto">
+                <Image src={logo} alt="logo" />
+              </div>
             </div>
-            <h3 className="text-white">PseudoNym</h3>
+            {isMobile ? (
+              <h4 className="text-white">PseudoNym</h4>
+            ) : (
+              <h3 className="text-white">PseudoNym</h3>
+            )}
           </a>
           <div className="flex gap-2 items-center">
-            <ConnectWallet />
+            {!isMobile && <ConnectWallet />}
             <MyProfile />
           </div>
         </nav>
-        <div className="grow flex justify-center">
-          {/* eslint-disable-next-line @next/next/no-img-element */}
-          <img className="w-[150px]" src="/nouns.png" alt="nouns" />
-        </div>
+        {!isMobile && (
+          <div className="grow flex justify-center">
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img className="w-[100px] md:w-[150px]" src="/nouns.png" alt="nouns" />
+          </div>
+        )}
       </div>
     </div>
   );

--- a/packages/frontend/src/components/MyProfile.tsx
+++ b/packages/frontend/src/components/MyProfile.tsx
@@ -30,7 +30,7 @@ export const MyProfile = () => {
     <>
       {localAddress && isValid ? (
         <div className="relative cursor-pointer" onClick={() => setOpenProfile(!openProfile)}>
-          <div className="flex items-center gap-2 rounded-md px-2 py-1 border border-white hover:scale-105 active:scale-100 transition-all">
+          <div className="flex items-center gap-2 rounded-xl px-2 py-1 border border-white hover:scale-105 active:scale-100 transition-all">
             <UserAvatar width={30} userId={localAddress} />
             <FontAwesomeIcon icon={faAngleDown} color="#ffffff" />
           </div>

--- a/packages/frontend/src/components/MyProfile.tsx
+++ b/packages/frontend/src/components/MyProfile.tsx
@@ -5,7 +5,7 @@ import useName from '@/hooks/useName';
 import { UserContext } from '@/pages/_app';
 import { useAccount } from 'wagmi';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faUser } from '@fortawesome/free-solid-svg-icons';
+import { faAngleDown, faUser } from '@fortawesome/free-solid-svg-icons';
 
 export const MyProfile = () => {
   const { address } = useAccount();
@@ -30,7 +30,10 @@ export const MyProfile = () => {
     <>
       {localAddress && isValid ? (
         <div className="relative cursor-pointer" onClick={() => setOpenProfile(!openProfile)}>
-          <UserAvatar width={50} userId={localAddress} />
+          <div className="flex items-center gap-2 rounded-md px-2 py-1 border border-white hover:scale-105 active:scale-100 transition-all">
+            <UserAvatar width={30} userId={localAddress} />
+            <FontAwesomeIcon icon={faAngleDown} color="#ffffff" />
+          </div>
           {openProfile ? (
             <div className="max-w-[150px] absolute top-full right-0 bg-white mt-2 border border-gray-200 rounded-xl cursor-pointer">
               <p className="secondary p-2">My identities</p>

--- a/packages/frontend/src/components/MyProfile.tsx
+++ b/packages/frontend/src/components/MyProfile.tsx
@@ -6,10 +6,11 @@ import { UserContext } from '@/pages/_app';
 import { useAccount } from 'wagmi';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faAngleDown, faUser } from '@fortawesome/free-solid-svg-icons';
+import ConnectWallet from './ConnectWallet';
 
 export const MyProfile = () => {
   const { address } = useAccount();
-  const { nymOptions, isValid } = useContext(UserContext) as UserContextType;
+  const { isMobile, nymOptions, isValid } = useContext(UserContext) as UserContextType;
   const { name } = useName({ userId: address });
 
   const [openProfile, setOpenProfile] = useState(false);
@@ -36,6 +37,14 @@ export const MyProfile = () => {
           </div>
           {openProfile ? (
             <div className="max-w-[150px] absolute top-full right-0 bg-white mt-2 border border-gray-200 rounded-xl cursor-pointer">
+              {isMobile && localAddress && isValid && (
+                <>
+                  <p className="secondary p-2">Wallet</p>
+                  <div className="w-full flex justify-center">
+                    <ConnectWallet />
+                  </div>
+                </>
+              )}
               <p className="secondary p-2">My identities</p>
               <div className="border-b border-dotted border-gray-300">
                 <a href={`/users/${localAddress}`}>

--- a/packages/frontend/src/components/Posts.tsx
+++ b/packages/frontend/src/components/Posts.tsx
@@ -95,7 +95,7 @@ export default function Posts(props: PostsProps) {
               ) : posts ? (
                 <>
                   {posts.map((post) => (
-                    <div className="flex gap-2" key={post.id}>
+                    <div className="w-full flex gap-2" key={post.id}>
                       <Upvote
                         upvotes={post.upvotes}
                         col={true}

--- a/packages/frontend/src/components/Posts.tsx
+++ b/packages/frontend/src/components/Posts.tsx
@@ -104,35 +104,35 @@ export default function Posts(props: PostsProps) {
         <div className="w-full bg-gray-50 flex flex-col justify-center items-center">
           <div className="bg-gray-50 min-h-screen w-full">
             <div className="flex flex-col gap-8 max-w-3xl mx-auto py-5 md:py-10 px-4 md:px-0">
-              <div className="flex flex-row-reverse md:flex-row justify-between">
-                {isMobile ? (
-                  <SortSelect
-                    options={filterOptions}
-                    selectedQuery={filter}
-                    setSelectedQuery={setFilter}
-                  />
-                ) : (
-                  <Filters
-                    filters={filterOptions}
-                    selectedFilter={filter}
-                    setSelectedFilter={setFilter}
-                  />
-                )}
-                <div className="grow-0">
-                  <MainButton
-                    color="#0E76FD"
-                    message="Start Discussion"
-                    loading={false}
-                    handler={() => setNewPostOpen(true)}
-                  />
-                </div>
-              </div>
               {isLoading ? (
                 <>
                   <Spinner />
                 </>
               ) : sortedPosts ? (
                 <>
+                  <div className="flex flex-row-reverse md:flex-row justify-between">
+                    {isMobile ? (
+                      <SortSelect
+                        options={filterOptions}
+                        selectedQuery={filter}
+                        setSelectedQuery={setFilter}
+                      />
+                    ) : (
+                      <Filters
+                        filters={filterOptions}
+                        selectedFilter={filter}
+                        setSelectedFilter={setFilter}
+                      />
+                    )}
+                    <div className="grow-0">
+                      <MainButton
+                        color="#0E76FD"
+                        message="Start Discussion"
+                        loading={false}
+                        handler={() => setNewPostOpen(true)}
+                      />
+                    </div>
+                  </div>
                   {sortedPosts.map((post) => (
                     <div className="w-full flex gap-2" key={post.id}>
                       <Upvote

--- a/packages/frontend/src/components/Posts.tsx
+++ b/packages/frontend/src/components/Posts.tsx
@@ -122,7 +122,7 @@ export default function Posts(props: PostsProps) {
                 </>
               ) : sortedPosts ? (
                 <>
-                  <div className="flex flex-row-reverse md:flex-row justify-between">
+                  <div className="flex justify-between">
                     {isMobile ? (
                       <SortSelect
                         options={filterOptions}

--- a/packages/frontend/src/components/Posts.tsx
+++ b/packages/frontend/src/components/Posts.tsx
@@ -44,6 +44,7 @@ export default function Posts(props: PostsProps) {
   const { errorMsg, setError } = useError();
   const router = useRouter();
   const { isMobile } = useContext(UserContext) as UserContextType;
+  const [postLoading, setPostLoading] = useState(false);
 
   const {
     isLoading,
@@ -73,6 +74,12 @@ export default function Posts(props: PostsProps) {
     }
   };
 
+  const pushPost = async (postId: string) => {
+    setPostLoading(true);
+    await router.push(`/posts/${postId}`);
+    setPostLoading(false);
+  };
+
   const [newPostOpen, setNewPostOpen] = useState(false);
   const [openPostId, setOpenPostId] = useState<string>(initOpenPostId ? initOpenPostId : '');
 
@@ -98,6 +105,11 @@ export default function Posts(props: PostsProps) {
         >
           <PostWithReplies postId={openPostId} />
         </Modal>
+      ) : null}
+      {postLoading ? (
+        <div className="fixed right-4 bottom-4 bg-gray-200 rounded-full p-2">
+          <Spinner />
+        </div>
       ) : null}
       <Header />
       <main className="flex w-full flex-col justify-center items-center">
@@ -147,7 +159,7 @@ export default function Posts(props: PostsProps) {
                         {...post}
                         userId={post.userId}
                         handleOpenPost={() => {
-                          if (isMobile) router.push(`/posts/${post.id}`);
+                          if (isMobile) pushPost(post.id);
                           else {
                             router.replace(window.location.href, `/posts/${post.id}`);
                             setOpenPostId(post.id);

--- a/packages/frontend/src/components/Posts.tsx
+++ b/packages/frontend/src/components/Posts.tsx
@@ -16,6 +16,7 @@ import { Modal } from './global/Modal';
 import { UserContext } from '@/pages/_app';
 import { UserContextType } from '@/types/components';
 import { Filters } from './post/Filters';
+import { SortSelect } from './post/SortSelect';
 
 const getPosts = async () => (await axios.get<IPostPreview[]>('/api/v1/posts')).data;
 
@@ -102,13 +103,21 @@ export default function Posts(props: PostsProps) {
       <main className="flex w-full flex-col justify-center items-center">
         <div className="w-full bg-gray-50 flex flex-col justify-center items-center">
           <div className="bg-gray-50 min-h-screen w-full">
-            <div className="flex flex-col gap-8 max-w-3xl mx-auto py-5 md:py-10 px-3 md:px-0">
-              <div className="flex flex-col-reverse gap-4 sm:flex-row justify-center sm:justify-between items-center">
-                <Filters
-                  filters={filterOptions}
-                  selectedFilter={filter}
-                  setSelectedFilter={setFilter}
-                />
+            <div className="flex flex-col gap-8 max-w-3xl mx-auto py-5 md:py-10 px-4 md:px-0">
+              <div className="flex flex-row-reverse md:flex-row justify-between">
+                {isMobile ? (
+                  <SortSelect
+                    options={filterOptions}
+                    selectedQuery={filter}
+                    setSelectedQuery={setFilter}
+                  />
+                ) : (
+                  <Filters
+                    filters={filterOptions}
+                    selectedFilter={filter}
+                    setSelectedFilter={setFilter}
+                  />
+                )}
                 <div className="grow-0">
                   <MainButton
                     color="#0E76FD"

--- a/packages/frontend/src/components/global/Modal.tsx
+++ b/packages/frontend/src/components/global/Modal.tsx
@@ -1,7 +1,9 @@
+import { UserContext } from '@/pages/_app';
+import { UserContextType } from '@/types/components';
 import { faXmark } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { Dialog } from '@headlessui/react';
-import { ReactNode } from 'react';
+import { ReactNode, useContext } from 'react';
 
 interface ModalProps {
   width?: string;
@@ -12,6 +14,8 @@ interface ModalProps {
 
 export const Modal = (props: ModalProps) => {
   const { width, startAtTop, handleClose, children } = props;
+  const { isMobile } = useContext(UserContext) as UserContextType;
+
   return (
     <Dialog open={true} onClose={handleClose} className="relative z-50">
       {/* The backdrop, rendered as a fixed sibling to the panel container */}
@@ -19,11 +23,11 @@ export const Modal = (props: ModalProps) => {
       <div className="fixed inset-0 overflow-y-auto">
         <div
           className="flex min-h-full justify-center"
-          style={{ alignItems: startAtTop ? 'top' : 'center' }}
+          style={{ alignItems: startAtTop ? 'top' : isMobile ? 'end' : 'center' }}
         >
           <Dialog.Panel
-            className="relative max-w-3xl bg-gray-50 mx-8 rounded-md"
-            style={{ width: width ? width : '100%' }}
+            className="relative max-w-none sm:max-w-3xl bg-gray-50 m-none sm:mx-8 rounded-md rounded-b-none sm:rounded-b-md"
+            style={{ width: width && !isMobile ? width : '100%' }}
           >
             <div className="absolute p-6 top-0 right-0 cursor-pointer">
               <FontAwesomeIcon icon={faXmark} color="#98A2B3" onClick={handleClose as any} />

--- a/packages/frontend/src/components/global/Modal.tsx
+++ b/packages/frontend/src/components/global/Modal.tsx
@@ -30,7 +30,12 @@ export const Modal = (props: ModalProps) => {
             style={{ width: width && !isMobile ? width : '100%' }}
           >
             <div className="absolute p-6 top-0 right-0 cursor-pointer">
-              <FontAwesomeIcon icon={faXmark} color="#98A2B3" onClick={handleClose as any} />
+              <FontAwesomeIcon
+                size={'xl'}
+                icon={faXmark}
+                color="#98A2B3"
+                onClick={handleClose as any}
+              />
             </div>
             {children}
           </Dialog.Panel>

--- a/packages/frontend/src/components/post/CopyLink.tsx
+++ b/packages/frontend/src/components/post/CopyLink.tsx
@@ -1,9 +1,12 @@
+import { UserContext } from '@/pages/_app';
+import { UserContextType } from '@/types/components';
 import { faCheck, faLink } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { useState } from 'react';
+import { useContext, useState } from 'react';
 
 export const CopyLink = (props: { id: string }) => {
   const { id } = props;
+  const { isMobile } = useContext(UserContext) as UserContextType;
 
   const [linkCopied, setLinkCopied] = useState<boolean>(false);
 
@@ -21,9 +24,11 @@ export const CopyLink = (props: { id: string }) => {
       }}
     >
       <FontAwesomeIcon icon={linkCopied ? faCheck : faLink} color={linkCopied ? '#0e76fd' : ''} />
-      <p className="secondary" style={{ fontWeight: linkCopied ? 'bold' : 'normal' }}>
-        {linkCopied ? 'Copied' : 'Copy Link'}
-      </p>
+      {!isMobile && (
+        <p className="secondary" style={{ fontWeight: linkCopied ? 'bold' : 'normal' }}>
+          {linkCopied ? 'Copied' : 'Copy Link'}
+        </p>
+      )}
     </div>
   );
 };

--- a/packages/frontend/src/components/post/CopyLink.tsx
+++ b/packages/frontend/src/components/post/CopyLink.tsx
@@ -24,11 +24,6 @@ export const CopyLink = (props: { id: string }) => {
       }}
     >
       <FontAwesomeIcon icon={linkCopied ? faCheck : faLink} color={linkCopied ? '#0e76fd' : ''} />
-      {!isMobile && (
-        <p className="secondary" style={{ fontWeight: linkCopied ? 'bold' : 'normal' }}>
-          {linkCopied ? 'Copied' : 'Copy Link'}
-        </p>
-      )}
     </div>
   );
 };

--- a/packages/frontend/src/components/post/Filters.tsx
+++ b/packages/frontend/src/components/post/Filters.tsx
@@ -6,7 +6,7 @@ interface FilterProps {
 export const Filters = (props: FilterProps) => {
   const { filters, selectedFilter, setSelectedFilter } = props;
   return (
-    <div className="flex gap-4">
+    <div className="flex flex-wrap gap-4">
       {Object.keys(filters).map((f) => (
         <button
           key={f}

--- a/packages/frontend/src/components/post/Filters.tsx
+++ b/packages/frontend/src/components/post/Filters.tsx
@@ -1,0 +1,23 @@
+interface FilterProps {
+  filters: { [key: string]: string };
+  selectedFilter: string;
+  setSelectedFilter: (filter: string) => void;
+}
+export const Filters = (props: FilterProps) => {
+  const { filters, selectedFilter, setSelectedFilter } = props;
+  return (
+    <div className="flex gap-4">
+      {Object.keys(filters).map((f) => (
+        <button
+          key={f}
+          className={`${
+            f === selectedFilter ? 'bg-gray-200' : 'bg-transparent'
+          } hover:bg-gray-200 px-4 py-2 rounded-xl`}
+          onClick={() => setSelectedFilter(f)}
+        >
+          <p className="font-semibold text-gray-500">{filters[f]}</p>
+        </button>
+      ))}
+    </div>
+  );
+};

--- a/packages/frontend/src/components/post/PostPreview.tsx
+++ b/packages/frontend/src/components/post/PostPreview.tsx
@@ -34,7 +34,7 @@ export const PostPreview = (postProps: PostProps) => {
       <div
         id={id}
         onClick={() => handleOpenPost('')}
-        className="rounded-2xl transition-all shadow-sm bg-white p-3 md:px-5 md:py-4 flex flex-col gap-4 justify-between border border-gray-200 hover:border-gray-300 hover:cursor-pointer w-full"
+        className="min-w-0 grow rounded-2xl transition-all shadow-sm bg-white p-3 md:px-5 md:py-4 flex flex-col gap-4 justify-between border border-gray-200 hover:border-gray-300 hover:cursor-pointer"
       >
         {root ? (
           <div className="flex flex-col gap-2">
@@ -81,7 +81,7 @@ export const PostPreview = (postProps: PostProps) => {
         ) : (
           <>
             <span>{body}</span>
-            <div className="w-full flex gap-2 justify-between items-center">
+            <div className="min-w-0 flex gap-2 justify-between items-center">
               <UserTag userId={userId} timestamp={timestamp} />
               <div className="flex gap-4">
                 <ReplyCount count={_count.descendants} />

--- a/packages/frontend/src/components/post/PostPreview.tsx
+++ b/packages/frontend/src/components/post/PostPreview.tsx
@@ -59,7 +59,7 @@ export const PostPreview = (postProps: PostProps) => {
                 </a>
               </p>
             ) : null}
-            <h4 className="tracking-tight">{title}</h4>
+            <h4 className="hover:underline tracking-tight">{title}</h4>
           </>
         )}
         {parent ? (

--- a/packages/frontend/src/components/post/PostPreview.tsx
+++ b/packages/frontend/src/components/post/PostPreview.tsx
@@ -81,7 +81,7 @@ export const PostPreview = (postProps: PostProps) => {
         ) : (
           <>
             <span>{body}</span>
-            <div className="min-w-0 flex gap-2 justify-between items-center">
+            <div className="min-w-0 flex flex-wrap gap-2 justify-between items-center">
               <UserTag userId={userId} timestamp={timestamp} />
               <div className="flex gap-4">
                 <ReplyCount count={_count.descendants} />

--- a/packages/frontend/src/components/post/PostPreview.tsx
+++ b/packages/frontend/src/components/post/PostPreview.tsx
@@ -39,20 +39,20 @@ export const PostPreview = (postProps: PostProps) => {
         {root ? (
           <div className="flex flex-col gap-2">
             <p>
-              <a href={`/users/${userId}`} className="postDetail hover:underline">
+              <a href={`/users/${userId}`} className="postDetail hover:underline break-words">
                 {userName}
               </a>
               <span className="secondary"> commented on </span>
               <span className="postDetail hover:underline">{root.title}</span>
             </p>
-            <a href={`/users/${root.userId}`} className="w-max secondary">
+            <a href={`/users/${root.userId}`} className="breakText secondary">
               Posted by <strong className="hover:underline">{rootName}</strong>
             </a>
           </div>
         ) : (
           <>
             {showUserHeader ? (
-              <p>
+              <p className="breakText">
                 <span className="secondary">Posted by </span>
                 <a href={`/users/${userId}`} className="postDetail hover:underline">
                   {userName}
@@ -81,7 +81,7 @@ export const PostPreview = (postProps: PostProps) => {
         ) : (
           <>
             <span>{body}</span>
-            <div className="flex justify-between items-center">
+            <div className="w-full flex gap-2 justify-between items-center">
               <UserTag userId={userId} timestamp={timestamp} />
               <div className="flex gap-4">
                 <ReplyCount count={_count.descendants} />

--- a/packages/frontend/src/components/post/PostWithReplies.tsx
+++ b/packages/frontend/src/components/post/PostWithReplies.tsx
@@ -9,7 +9,6 @@ import { ReplyCount } from './ReplyCount';
 import { UserTag } from './UserTag';
 import { Upvote } from '../Upvote';
 import { PrefixedHex } from '@personaelabs/nymjs';
-import { Modal } from '../global/Modal';
 import Spinner from '../global/Spinner';
 import { RetryError } from '../global/RetryError';
 import useError from '@/hooks/useError';
@@ -18,7 +17,7 @@ const getPostById = async (postId: string, fromRoot = false) =>
   (await axios.get<IPostWithReplies>(`/api/v1/posts/${postId}?fromRoot=${fromRoot}`)).data;
 
 export const PostWithReplies = (postWithRepliesProps: PostWithRepliesProps) => {
-  const { writerToShow, handleClose, postId } = postWithRepliesProps;
+  const { writerToShow, postId } = postWithRepliesProps;
   const fromRoot = true;
   const { errorMsg, setError } = useError();
 
@@ -70,7 +69,7 @@ export const PostWithReplies = (postWithRepliesProps: PostWithRepliesProps) => {
   }, [postId, singlePost]);
 
   return (
-    <Modal startAtTop={true} handleClose={handleClose}>
+    <>
       {singlePost ? (
         <>
           <div className="flex flex-col gap-4 py-8 px-12 md:px-12 md:py-10">
@@ -82,7 +81,7 @@ export const PostWithReplies = (postWithRepliesProps: PostWithRepliesProps) => {
               </div>
               <p>{singlePost.body}</p>
             </div>
-            <div className="flex justify-between pt-2 border-t border-dotted border-gray-300 items-center">
+            <div className="flex flex-wrap justify-between pt-2 border-t border-dotted border-gray-300 items-center">
               <UserTag userId={singlePost.userId} timestamp={singlePost.timestamp} />
               <div className="flex gap-2">
                 <ReplyCount count={singlePost.replies.length} />
@@ -110,7 +109,7 @@ export const PostWithReplies = (postWithRepliesProps: PostWithRepliesProps) => {
           </div>
         </>
       ) : (
-        <div className="h-full flex flex-col justify-center">
+        <div className="h-screen flex flex-col justify-center">
           {isLoading ? (
             <Spinner />
           ) : isError ? (
@@ -118,6 +117,6 @@ export const PostWithReplies = (postWithRepliesProps: PostWithRepliesProps) => {
           ) : null}
         </div>
       )}
-    </Modal>
+    </>
   );
 };

--- a/packages/frontend/src/components/post/PostWithReplies.tsx
+++ b/packages/frontend/src/components/post/PostWithReplies.tsx
@@ -93,7 +93,7 @@ export const PostWithReplies = (postWithRepliesProps: PostWithRepliesProps) => {
               </div>
             </div>
           </div>
-          <div className="flex flex-col gap-8 w-full bg-gray-50 px-12 py-8">
+          <div className="flex flex-col gap-8 w-full bg-gray-50 px-8 py-8">
             <PostWriter
               parentId={singlePost.id as PrefixedHex}
               onSuccess={refetchAndScrollToPost}

--- a/packages/frontend/src/components/post/PostWithReplies.tsx
+++ b/packages/frontend/src/components/post/PostWithReplies.tsx
@@ -81,7 +81,7 @@ export const PostWithReplies = (postWithRepliesProps: PostWithRepliesProps) => {
               </div>
               <p>{singlePost.body}</p>
             </div>
-            <div className="flex flex-wrap justify-between pt-2 border-t border-dotted border-gray-300 items-center">
+            <div className="flex gap-2 flex-wrap justify-between pt-2 border-t border-dotted border-gray-300 items-center">
               <UserTag userId={singlePost.userId} timestamp={singlePost.timestamp} />
               <div className="flex gap-2">
                 <ReplyCount count={singlePost.replies.length} />
@@ -93,7 +93,7 @@ export const PostWithReplies = (postWithRepliesProps: PostWithRepliesProps) => {
               </div>
             </div>
           </div>
-          <div className="flex flex-col gap-8 w-full bg-gray-50 px-8 py-8">
+          <div className="flex grow flex-col gap-8 w-full bg-gray-50 px-8 py-8">
             <PostWriter
               parentId={singlePost.id as PrefixedHex}
               onSuccess={refetchAndScrollToPost}

--- a/packages/frontend/src/components/post/PostWithReplies.tsx
+++ b/packages/frontend/src/components/post/PostWithReplies.tsx
@@ -72,7 +72,7 @@ export const PostWithReplies = (postWithRepliesProps: PostWithRepliesProps) => {
     <>
       {singlePost ? (
         <>
-          <div className="flex flex-col gap-4 py-8 px-12 md:px-12 md:py-10">
+          <div className="flex flex-col gap-4 py-8 px-8 md:px-12 md:py-10">
             <div className="flex flex-col gap-3">
               <div className="flex justify-between item-center">
                 <div className="self-start line-clamp-2">

--- a/packages/frontend/src/components/post/SingleReply.tsx
+++ b/packages/frontend/src/components/post/SingleReply.tsx
@@ -38,11 +38,11 @@ export const SingleReply = (props: SingleReplyProps) => {
       <UserTag userId={userId} timestamp={timestamp} />
       <div className="flex flex-col gap-2 ml-3 pl-2 border-l border-dotted border-gray-300">
         <span>{body}</span>
-        <div className="flex justify-between items-center py-2 border-t border-gray-300">
+        <div className="flex flex-wrap justify-between items-center py-2 border-t border-gray-300">
           <Upvote upvotes={upvotes} postId={id} onSuccess={onSuccess}>
             <p>{upvotes.length}</p>
           </Upvote>
-          <div className="flex gap-4 justify-center items-center">
+          <div className="flex flex-wrap gap-4 justify-center items-center">
             <ReplyCount count={replyCount} />
             <div
               className="flex gap-2 items-center cursor-pointer hoverIcon"

--- a/packages/frontend/src/components/post/SortSelect.tsx
+++ b/packages/frontend/src/components/post/SortSelect.tsx
@@ -1,0 +1,21 @@
+interface SortSelectProps {
+  options: { [key: string]: string };
+  selectedQuery: string;
+  setSelectedQuery: (filter: string) => void;
+}
+export const SortSelect = (props: SortSelectProps) => {
+  const { options, selectedQuery, setSelectedQuery } = props;
+  return (
+    <select
+      className="outline-none bg-transparent font-semibold"
+      value={selectedQuery}
+      onChange={(e) => setSelectedQuery(e.target.value)}
+    >
+      {Object.keys(options).map((s) => (
+        <option key={s} value={s}>
+          {options[s]}
+        </option>
+      ))}
+    </select>
+  );
+};

--- a/packages/frontend/src/components/post/UserTag.tsx
+++ b/packages/frontend/src/components/post/UserTag.tsx
@@ -1,8 +1,10 @@
+import { UserContext } from '@/pages/_app';
 import { UserAvatar } from '../global/UserAvatar';
 import useName from '@/hooks/useName';
-import { NameType } from '@/types/components';
+import { NameType, UserContextType } from '@/types/components';
 import dayjs from 'dayjs';
 import relativeTime from 'dayjs/plugin/relativeTime';
+import { useContext } from 'react';
 dayjs.extend(relativeTime);
 
 interface UserTagProps {
@@ -15,6 +17,7 @@ interface UserTagProps {
 export const UserTag = (props: UserTagProps) => {
   const { userId, avatarWidth, timestamp, lastActive, hideLink } = props;
   const { name, isDoxed } = useName({ userId });
+  const { isMobile } = useContext(UserContext) as UserContextType;
 
   return (
     // stop post modal from opening on click of user page link
@@ -38,7 +41,7 @@ export const UserTag = (props: UserTagProps) => {
 
         {lastActive && (
           <div className="flex gap-1 shrink-0 secondary">
-            <p>Last active </p>
+            {!isMobile && <p>Last active </p>}
             <p className="font-semibold">{dayjs(lastActive).fromNow()}</p>
           </div>
         )}

--- a/packages/frontend/src/components/post/UserTag.tsx
+++ b/packages/frontend/src/components/post/UserTag.tsx
@@ -21,7 +21,10 @@ export const UserTag = (props: UserTagProps) => {
 
   return (
     // stop post modal from opening on click of user page link
-    <div className="min-w-0 shrink flex gap-2 items-center" onClick={(e) => e.stopPropagation()}>
+    <div
+      className="min-w-0 shrink grow basis-2/3 max-w-full flex gap-2 items-center"
+      onClick={(e) => e.stopPropagation()}
+    >
       <UserAvatar
         type={isDoxed ? NameType.DOXED : NameType.PSEUDO}
         userId={userId}

--- a/packages/frontend/src/components/post/UserTag.tsx
+++ b/packages/frontend/src/components/post/UserTag.tsx
@@ -18,18 +18,21 @@ export const UserTag = (props: UserTagProps) => {
 
   return (
     // stop post modal from opening on click of user page link
-    <div className="flex gap-2 items-center flex-wrap" onClick={(e) => e.stopPropagation()}>
+    <div className="min-w-0 shrink flex gap-2 items-center" onClick={(e) => e.stopPropagation()}>
       <UserAvatar
         type={isDoxed ? NameType.DOXED : NameType.PSEUDO}
         userId={userId}
         width={avatarWidth || 30}
       />
-      <div className="flex flex-col gap-1 shrink overflow-hidden">
+      <div className="min-w-0 flex flex-col gap-1">
         {hideLink ? (
-          <p className="overflow-hidden text-ellipsis whitespace-nowrap font-semibold">{name}</p>
+          <p className="font-semibold breakText">{name}</p>
         ) : (
-          <a href={`/users/${userId}`} className="outline-none overflow-hidden">
-            <p className="text-ellipsis whitespace-nowrap font-semibold hover:underline">{name}</p>
+          <a
+            href={`/users/${userId}`}
+            className="font-semibold hover:underline breakText outline-none"
+          >
+            {name}
           </a>
         )}
 
@@ -42,7 +45,7 @@ export const UserTag = (props: UserTagProps) => {
       </div>
 
       {timestamp && (
-        <div className="flex gap-2 shrink-0">
+        <div className="shrink-0 flex gap-2">
           <p className="secondary">-</p>
           <p className="secondary">{dayjs(timestamp).fromNow()}</p>
         </div>

--- a/packages/frontend/src/components/post/UserTag.tsx
+++ b/packages/frontend/src/components/post/UserTag.tsx
@@ -18,18 +18,18 @@ export const UserTag = (props: UserTagProps) => {
 
   return (
     // stop post modal from opening on click of user page link
-    <div className="flex gap-2 items-center" onClick={(e) => e.stopPropagation()}>
+    <div className="flex gap-2 items-center flex-wrap" onClick={(e) => e.stopPropagation()}>
       <UserAvatar
         type={isDoxed ? NameType.DOXED : NameType.PSEUDO}
         userId={userId}
         width={avatarWidth || 30}
       />
-      <div className="flex flex-col gap-1 shrink-0">
+      <div className="flex flex-col gap-1 shrink overflow-hidden">
         {hideLink ? (
-          <p className="font-semibold">{name}</p>
+          <p className="overflow-hidden text-ellipsis whitespace-nowrap font-semibold">{name}</p>
         ) : (
-          <a href={`/users/${userId}`} className="outline-none">
-            <p className="font-semibold hover:underline">{name}</p>
+          <a href={`/users/${userId}`} className="outline-none overflow-hidden">
+            <p className="text-ellipsis whitespace-nowrap font-semibold hover:underline">{name}</p>
           </a>
         )}
 

--- a/packages/frontend/src/components/userInput/NameSelect.tsx
+++ b/packages/frontend/src/components/userInput/NameSelect.tsx
@@ -64,8 +64,8 @@ export const NameSelect = (props: NameSelectProps) => {
           setSelectedName={setSelectedName}
         />
       ) : null}
-      <p className="secondary">Posting as</p>
-      <div className="relative w-[30%]" ref={divRef}>
+      <p className="secondary shrink-0">Posting as</p>
+      <div className="relative w-auto md:w-[30%]" ref={divRef}>
         <div
           className="bg-white flex gap-2 justify-between border items-center border-gray-200 rounded-xl px-2 py-2.5 cursor-pointer"
           onClick={() => setOpenSelect(!openSelect)}

--- a/packages/frontend/src/components/userInput/NameSelect.tsx
+++ b/packages/frontend/src/components/userInput/NameSelect.tsx
@@ -78,9 +78,7 @@ export const NameSelect = (props: NameSelectProps) => {
                 width={20}
               />
             )}
-            <p className="overflow-hidden text-ellipsis whitespace-nowrap">
-              {selectedName ? selectedName.name : 'No Nym Selected'}
-            </p>
+            <p className="breakText">{selectedName ? selectedName.name : 'No Nym Selected'}</p>
           </div>
           <FontAwesomeIcon icon={openSelect ? faAngleUp : faAngleDown} />
         </div>
@@ -114,9 +112,7 @@ export const NameSelect = (props: NameSelectProps) => {
                           userId={getUserIdFromName(nym)}
                           width={20}
                         />
-                        <p className="shrink overflow-hidden text-ellipsis whitespace-nowrap">
-                          {nym.name}
-                        </p>
+                        <p className="shrink breakText">{nym.name}</p>
                       </div>
                       <FontAwesomeIcon
                         icon={faCheck}
@@ -144,9 +140,7 @@ export const NameSelect = (props: NameSelectProps) => {
                   userId={getUserIdFromName(doxedName)}
                   width={20}
                 />
-                <p className="shrink overflow-hidden text-ellipsis whitespace-nowrap">
-                  {doxedName.name}
-                </p>
+                <p className="shrink breakText">{doxedName.name}</p>
               </div>
               <FontAwesomeIcon
                 icon={faCheck}

--- a/packages/frontend/src/components/userInput/PostWriter.tsx
+++ b/packages/frontend/src/components/userInput/PostWriter.tsx
@@ -136,7 +136,7 @@ export const PostWriter = ({ parentId, handleCloseWriter, onSuccess }: IWriterPr
               message={'Send'}
               disabled={!body || (parentId === '0x0' && !title)}
             >
-              {hasSignedPost ? (
+              {hasSignedPost && sendingPost ? (
                 <p>
                   Proving<span className="dot1">.</span>
                   <span className="dot2">.</span>

--- a/packages/frontend/src/hooks/useUserInfo.ts
+++ b/packages/frontend/src/hooks/useUserInfo.ts
@@ -39,6 +39,8 @@ const useUserInfo = ({ address }: { address?: PrefixedHex }) => {
   const [nymOptions, setNymOptions] = useState<ClientName[]>(getNymOptions(address));
   const [isValid, setIsValid] = useState(true);
 
+  console.log({ nymOptions });
+
   useEffect(() => {
     async function determineValidUser() {
       const valid = address ? await isValidMember(address) : true;

--- a/packages/frontend/src/hooks/useUserInfo.ts
+++ b/packages/frontend/src/hooks/useUserInfo.ts
@@ -39,8 +39,6 @@ const useUserInfo = ({ address }: { address?: PrefixedHex }) => {
   const [nymOptions, setNymOptions] = useState<ClientName[]>(getNymOptions(address));
   const [isValid, setIsValid] = useState(true);
 
-  console.log({ nymOptions });
-
   useEffect(() => {
     async function determineValidUser() {
       const valid = address ? await isValidMember(address) : true;

--- a/packages/frontend/src/pages/_app.tsx
+++ b/packages/frontend/src/pages/_app.tsx
@@ -10,7 +10,7 @@ import Head from 'next/head';
 import { ValidUserWarning } from '@/components/global/ValidUserWarning';
 import { getDefaultWallets } from '@rainbow-me/rainbowkit';
 import { polygon, optimism } from 'viem/chains';
-import { createContext } from 'react';
+import { createContext, useEffect, useState } from 'react';
 import useUserInfo from '@/hooks/useUserInfo';
 import { UserContextType } from '@/types/components';
 
@@ -37,10 +37,21 @@ export default function App({ Component, pageProps }: AppProps) {
   const { address } = useAccount();
   const { nymOptions, setNymOptions, isValid } = useUserInfo({ address: address });
 
+  const [isMobile, setIsMobile] = useState(false);
+
+  useEffect(() => {
+    const handleResize = () => setIsMobile(window.innerWidth <= 768);
+    handleResize();
+    window.addEventListener('resize', handleResize);
+    return () => {
+      window.removeEventListener('resize', handleResize);
+    };
+  }, []);
+
   return (
     <QueryClientProvider client={queryClient}>
       <WagmiConfig config={appConfig}>
-        <UserContext.Provider value={{ nymOptions, setNymOptions, isValid }}>
+        <UserContext.Provider value={{ isMobile, nymOptions, setNymOptions, isValid }}>
           <Head>
             <link type="favicon" rel="icon" href="/favicon-3.ico" />
           </Head>

--- a/packages/frontend/src/pages/posts/[postId].tsx
+++ b/packages/frontend/src/pages/posts/[postId].tsx
@@ -41,10 +41,13 @@ export default function PostId({ post }: { post?: IPostSimple }) {
         (isMobile ? (
           <>
             <Header />
-            <a className="flex px-8 pt-6 gap-1 items-center underline" href={'/'}>
+            <div
+              className="flex px-8 pt-6 gap-1 items-center underline"
+              onClick={() => router.push('/')}
+            >
               <FontAwesomeIcon icon={faArrowLeft} className="secondary" />
               <p>All posts</p>
-            </a>
+            </div>
             <PostWithReplies postId={openPostId} />
           </>
         ) : (

--- a/packages/frontend/src/pages/posts/[postId].tsx
+++ b/packages/frontend/src/pages/posts/[postId].tsx
@@ -8,6 +8,9 @@ import { UserContext } from '../_app';
 import { UserContextType } from '@/types/components';
 import { PostWithReplies } from '@/components/post/PostWithReplies';
 import { useContext } from 'react';
+import { Header } from '@/components/Header';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faArrowLeft } from '@fortawesome/free-solid-svg-icons';
 
 // This function returns the IPostSimple post object as a prop to PostId
 export async function getServerSideProps(
@@ -36,7 +39,14 @@ export default function PostId({ post }: { post?: IPostSimple }) {
       <Seo title={TITLE} description={description} />
       {openPostId &&
         (isMobile ? (
-          <PostWithReplies postId={openPostId} />
+          <>
+            <Header />
+            <a className="flex px-8 pt-6 gap-1 items-center underline" href={'/'}>
+              <FontAwesomeIcon icon={faArrowLeft} className="secondary" />
+              <p>All posts</p>
+            </a>
+            <PostWithReplies postId={openPostId} />
+          </>
         ) : (
           <Posts initOpenPostId={openPostId} />
         ))}

--- a/packages/frontend/src/pages/posts/[postId].tsx
+++ b/packages/frontend/src/pages/posts/[postId].tsx
@@ -4,6 +4,10 @@ import { GetServerSidePropsContext } from 'next';
 import { IPostSimple } from '@/types/api/postSelectSimple';
 import { getSimplePost } from '../api/v1/utils';
 import { Seo, TITLE } from '@/components/global/Seo';
+import { UserContext } from '../_app';
+import { UserContextType } from '@/types/components';
+import { PostWithReplies } from '@/components/post/PostWithReplies';
+import { useContext } from 'react';
 
 // This function returns the IPostSimple post object as a prop to PostId
 export async function getServerSideProps(
@@ -26,10 +30,16 @@ export default function PostId({ post }: { post?: IPostSimple }) {
   const router = useRouter();
   const openPostId = router.query.postId as string;
   const { description } = buildSeo(post);
+  const { isMobile } = useContext(UserContext) as UserContextType;
   return (
     <>
       <Seo title={TITLE} description={description} />
-      {openPostId && <Posts initOpenPostId={openPostId} />}
+      {openPostId &&
+        (isMobile ? (
+          <PostWithReplies postId={openPostId} />
+        ) : (
+          <Posts initOpenPostId={openPostId} />
+        ))}
     </>
   );
 }

--- a/packages/frontend/src/pages/posts/[postId].tsx
+++ b/packages/frontend/src/pages/posts/[postId].tsx
@@ -35,16 +35,13 @@ export default function PostId({ post }: { post?: IPostSimple }) {
   const { description } = buildSeo(post);
   const { isMobile } = useContext(UserContext) as UserContextType;
   return (
-    <>
+    <div className="flex flex-col h-screen">
       <Seo title={TITLE} description={description} />
       {openPostId &&
         (isMobile ? (
           <>
             <Header />
-            <div
-              className="flex px-8 pt-6 gap-1 items-center underline"
-              onClick={() => router.push('/')}
-            >
+            <div className="flex p-6 gap-1 items-center underline" onClick={() => router.push('/')}>
               <FontAwesomeIcon icon={faArrowLeft} className="secondary" />
               <p>All posts</p>
             </div>
@@ -53,6 +50,6 @@ export default function PostId({ post }: { post?: IPostSimple }) {
         ) : (
           <Posts initOpenPostId={openPostId} />
         ))}
-    </>
+    </div>
   );
 }

--- a/packages/frontend/src/pages/users.tsx
+++ b/packages/frontend/src/pages/users.tsx
@@ -40,7 +40,13 @@ const sortUsers = (users: UserPostCounts[] | undefined, query: string) => {
   const queryString = query as keyof UserPostCounts;
   return users
     ? users.sort((a, b) => {
-        return (b[queryString] as number) - (a[queryString] as number);
+        if (queryString === 'lastActive') {
+          const val1 = b['lastActive'] || new Date();
+          const val2 = a['lastActive'] || new Date();
+
+          return Number(new Date(val1)) - Number(new Date(val2));
+        }
+        return Number(b[queryString]) - Number(a[queryString]);
       })
     : users;
 };
@@ -74,107 +80,105 @@ export default function Users() {
 
   const sortedUsers = useMemo(() => sortUsers(filteredUsers, sort), [filteredUsers, sort]);
 
+  console.log({ sortedUsers });
+
   return (
     <main>
-      <h1>Users</h1>
-      <br></br>
       <Header />
-      <main>
-        <div className="w-full bg-gray-50 flex flex-col justify-center items-center">
-          <div className="bg-gray-50 min-h-screen w-full">
-            <div className="flex flex-col gap-8 max-w-3xl mx-auto py-5 md:py-10 px-3 md:px-0">
-              <div className="flex justify-between">
-                <h3>Users</h3>
-                <input
-                  className="outline-none bg-white px-2"
-                  type="text"
-                  placeholder="Search"
-                  value={searchQuery}
-                  onChange={(event) => {
-                    setSearchQuery(event.target.value);
-                    filterBySearch(filteredUsers, searchQuery);
-                  }}
-                />
-              </div>
-              {isLoading ? (
-                <Spinner />
-              ) : users && filteredUsers ? (
-                <>
-                  <div className="flex justify-between">
-                    <div className="flex gap-4">
-                      {Object.values(Filter).map((f) => (
-                        <button
-                          key={f}
-                          className={`${
-                            Filter[f] === filter ? 'bg-gray-200' : 'bg-transparent'
-                          } hover:bg-gray-200 px-4 py-2 rounded-xl`}
-                          onClick={() => setFilter(f)}
-                        >
-                          <p className="font-semibold text-gray-500">{f}</p>
-                        </button>
-                      ))}
-                    </div>
-                    <div className="flex gap-1 items-center">
-                      <p className="text-gray-500">Sort by</p>
-                      <select
-                        className="outline-none bg-transparent font-semibold"
-                        value={sort}
-                        onChange={(e) => setSort(e.target.value)}
-                      >
-                        {Object.keys(sortOptions).map((s) => (
-                          <option key={s} value={s}>
-                            {sortOptions[s]}
-                          </option>
-                        ))}
-                      </select>
-                    </div>
-                  </div>
-                  {sortedUsers && sortedUsers.length > 0 ? (
-                    sortedUsers.map((u) => (
-                      <a
-                        href={`/users/${u.userId}`}
-                        className="outline-none rounded-2xl transition-all shadow-sm bg-white p-3 md:px-5 md:py-4 flex gap-4 justify-between border border-gray-200 hover:border-gray-300 hover:cursor-pointer w-full"
-                        key={u.userId}
-                      >
-                        <div className="hover:no-underline">
-                          <UserTag
-                            hideLink={true}
-                            avatarWidth={50}
-                            userId={u.userId}
-                            lastActive={u.lastActive}
-                          ></UserTag>
-                        </div>
-                        <div className="flex gap-4">
-                          <span className="m-auto">
-                            <strong>{u.numPosts}</strong>
-                            {' Posts'}
-                          </span>
-                          <span className="m-auto">
-                            <strong>{u.numReplies}</strong>
-                            {' Replies'}
-                          </span>
-                          <span className="m-auto">
-                            <strong>{u.upvotes}</strong>
-                            {' Votes'}
-                          </span>
-                        </div>
-                      </a>
-                    ))
-                  ) : (
-                    <p className="text-center">No Users Found</p>
-                  )}
-                </>
-              ) : (
-                <RetryError
-                  message="Could not fetch users."
-                  error={errorMsg}
-                  refetchHandler={refetch}
-                />
-              )}
+      <div className="w-full bg-gray-50 flex flex-col justify-center items-center">
+        <div className="bg-gray-50 min-h-screen w-full">
+          <div className="flex flex-col gap-8 max-w-3xl mx-auto py-5 md:py-10 px-3 md:px-0">
+            <div className="flex justify-between">
+              <h3>Users</h3>
+              <input
+                className="outline-none bg-white px-2"
+                type="text"
+                placeholder="Search"
+                value={searchQuery}
+                onChange={(event) => {
+                  setSearchQuery(event.target.value);
+                  filterBySearch(filteredUsers, searchQuery);
+                }}
+              />
             </div>
+            {isLoading ? (
+              <Spinner />
+            ) : users && filteredUsers ? (
+              <>
+                <div className="flex justify-between">
+                  <div className="flex gap-4">
+                    {Object.values(Filter).map((f) => (
+                      <button
+                        key={f}
+                        className={`${
+                          Filter[f] === filter ? 'bg-gray-200' : 'bg-transparent'
+                        } hover:bg-gray-200 px-4 py-2 rounded-xl`}
+                        onClick={() => setFilter(f)}
+                      >
+                        <p className="font-semibold text-gray-500">{f}</p>
+                      </button>
+                    ))}
+                  </div>
+                  <div className="flex gap-1 items-center">
+                    <p className="text-gray-500">Sort by</p>
+                    <select
+                      className="outline-none bg-transparent font-semibold"
+                      value={sort}
+                      onChange={(e) => setSort(e.target.value)}
+                    >
+                      {Object.keys(sortOptions).map((s) => (
+                        <option key={s} value={s}>
+                          {sortOptions[s]}
+                        </option>
+                      ))}
+                    </select>
+                  </div>
+                </div>
+                {sortedUsers && sortedUsers.length > 0 ? (
+                  sortedUsers.map((u) => (
+                    <a
+                      href={`/users/${u.userId}`}
+                      className="outline-none rounded-2xl transition-all shadow-sm bg-white p-3 md:px-5 md:py-4 flex gap-4 justify-between border border-gray-200 hover:border-gray-300 hover:cursor-pointer w-full"
+                      key={u.userId}
+                    >
+                      <div className="hover:no-underline">
+                        <UserTag
+                          hideLink={true}
+                          avatarWidth={50}
+                          userId={u.userId}
+                          lastActive={u.lastActive}
+                        ></UserTag>
+                      </div>
+                      <div className="flex gap-4">
+                        <span className="m-auto">
+                          <strong>{u.numPosts}</strong>
+                          {' Posts'}
+                        </span>
+                        <span className="m-auto">
+                          <strong>{u.numReplies}</strong>
+                          {' Replies'}
+                        </span>
+                        <span className="m-auto">
+                          <strong>{u.upvotes}</strong>
+                          {' Votes'}
+                        </span>
+                      </div>
+                    </a>
+                  ))
+                ) : (
+                  <p className="text-center">No Users Found</p>
+                )}
+              </>
+            ) : (
+              <RetryError
+                message="Could not fetch users."
+                error={errorMsg}
+                refetchHandler={refetch}
+              />
+            )}
           </div>
         </div>
-      </main>
+      </div>
     </main>
   );
 }

--- a/packages/frontend/src/pages/users.tsx
+++ b/packages/frontend/src/pages/users.tsx
@@ -70,7 +70,7 @@ export default function Users() {
   });
 
   const [filter, setFilter] = useState<Filter>(Filter.All);
-  const [sort, setSort] = useState<string>(sortOptions.lastActive);
+  const [sort, setSort] = useState<string>('lastActive');
 
   const [searchQuery, setSearchQuery] = useState<string>('');
   const filteredUsers = useMemo(
@@ -105,7 +105,7 @@ export default function Users() {
               <Spinner />
             ) : users && filteredUsers ? (
               <>
-                <div className="flex justify-between">
+                <div className="flex flex-col sm:flex-row gap-4 justify-between">
                   <div className="flex gap-4">
                     {Object.values(Filter).map((f) => (
                       <button
@@ -138,29 +138,29 @@ export default function Users() {
                   sortedUsers.map((u) => (
                     <a
                       href={`/users/${u.userId}`}
-                      className="outline-none rounded-2xl transition-all shadow-sm bg-white p-3 md:px-5 md:py-4 flex gap-4 justify-between border border-gray-200 hover:border-gray-300 hover:cursor-pointer w-full"
+                      className="flex gap-4 justify-between outline-none rounded-2xl transition-all shadow-sm bg-white p-3 md:px-5 md:py-4 border border-gray-200 hover:border-gray-300 hover:cursor-pointer w-full"
                       key={u.userId}
                     >
-                      <div className="hover:no-underline">
+                      <div className="min-w-0 hover:no-underline">
                         <UserTag
                           hideLink={true}
                           avatarWidth={50}
                           userId={u.userId}
                           lastActive={u.lastActive}
-                        ></UserTag>
+                        />
                       </div>
-                      <div className="flex gap-4">
-                        <span className="m-auto">
+                      <div className="flex gap-2 sm:gap-4 text-center">
+                        <span className="my-auto">
                           <strong>{u.numPosts}</strong>
-                          {' Posts'}
+                          {u.numPosts === 1 ? ' Post' : ' Posts'}
                         </span>
-                        <span className="m-auto">
+                        <span className="my-auto">
                           <strong>{u.numReplies}</strong>
-                          {' Replies'}
+                          {u.numReplies === 1 ? ' Reply' : ' Replies'}
                         </span>
-                        <span className="m-auto">
+                        <span className="my-auto">
                           <strong>{u.upvotes}</strong>
-                          {' Votes'}
+                          {u.upvotes === 1 ? ' Vote' : ' Votes'}
                         </span>
                       </div>
                     </a>

--- a/packages/frontend/src/pages/users.tsx
+++ b/packages/frontend/src/pages/users.tsx
@@ -7,14 +7,15 @@ import { UserPostCounts } from '@/types/api';
 import { useQuery } from '@tanstack/react-query';
 import axios from 'axios';
 import { useMemo, useState } from 'react';
+import { Filters } from '@/components/post/Filters';
 
 const getUsers = async () => (await axios.get<UserPostCounts[]>('/api/v1/users')).data;
 
-enum Filter {
-  All = 'All',
-  Doxed = 'Doxed',
-  Pseudo = 'Pseudo',
-}
+const filterOptions: { [key: string]: string } = {
+  all: 'All',
+  doxed: 'Doxed',
+  pseudo: 'Pseudo',
+};
 
 const sortOptions: { [key: string]: string } = {
   lastActive: 'Last Active',
@@ -30,10 +31,10 @@ const filterBySearch = (users: UserPostCounts[] | undefined, query: string) => {
   });
 };
 
-const filterUsers = (users: UserPostCounts[] | undefined, filter: Filter, searchQuery: string) => {
+const filterUsers = (users: UserPostCounts[] | undefined, filter: string, searchQuery: string) => {
   let searchResult = searchQuery ? filterBySearch(users, searchQuery) : users;
-  if (filter === Filter.All) return searchQuery ? filterBySearch(searchResult, searchQuery) : users;
-  else return searchResult?.filter((u) => u.doxed === (filter === Filter.Doxed));
+  if (filter === 'all') return searchQuery ? filterBySearch(searchResult, searchQuery) : users;
+  else return searchResult?.filter((u) => u.doxed === (filter === 'doxed'));
 };
 
 const sortUsers = (users: UserPostCounts[] | undefined, query: string) => {
@@ -69,7 +70,7 @@ export default function Users() {
     },
   });
 
-  const [filter, setFilter] = useState<Filter>(Filter.All);
+  const [filter, setFilter] = useState<string>('all');
   const [sort, setSort] = useState<string>('lastActive');
 
   const [searchQuery, setSearchQuery] = useState<string>('');
@@ -79,8 +80,6 @@ export default function Users() {
   );
 
   const sortedUsers = useMemo(() => sortUsers(filteredUsers, sort), [filteredUsers, sort]);
-
-  console.log({ sortedUsers });
 
   return (
     <main>
@@ -106,19 +105,11 @@ export default function Users() {
             ) : users && filteredUsers ? (
               <>
                 <div className="flex flex-col sm:flex-row gap-4 justify-between">
-                  <div className="flex gap-4">
-                    {Object.values(Filter).map((f) => (
-                      <button
-                        key={f}
-                        className={`${
-                          Filter[f] === filter ? 'bg-gray-200' : 'bg-transparent'
-                        } hover:bg-gray-200 px-4 py-2 rounded-xl`}
-                        onClick={() => setFilter(f)}
-                      >
-                        <p className="font-semibold text-gray-500">{f}</p>
-                      </button>
-                    ))}
-                  </div>
+                  <Filters
+                    filters={filterOptions}
+                    selectedFilter={filter}
+                    setSelectedFilter={setFilter}
+                  />
                   <div className="flex gap-1 items-center">
                     <p className="text-gray-500">Sort by</p>
                     <select

--- a/packages/frontend/src/pages/users.tsx
+++ b/packages/frontend/src/pages/users.tsx
@@ -8,6 +8,7 @@ import { useQuery } from '@tanstack/react-query';
 import axios from 'axios';
 import { useMemo, useState } from 'react';
 import { Filters } from '@/components/post/Filters';
+import { SortSelect } from '@/components/post/SortSelect';
 
 const getUsers = async () => (await axios.get<UserPostCounts[]>('/api/v1/users')).data;
 
@@ -112,17 +113,11 @@ export default function Users() {
                   />
                   <div className="flex gap-1 items-center">
                     <p className="text-gray-500">Sort by</p>
-                    <select
-                      className="outline-none bg-transparent font-semibold"
-                      value={sort}
-                      onChange={(e) => setSort(e.target.value)}
-                    >
-                      {Object.keys(sortOptions).map((s) => (
-                        <option key={s} value={s}>
-                          {sortOptions[s]}
-                        </option>
-                      ))}
-                    </select>
+                    <SortSelect
+                      options={sortOptions}
+                      selectedQuery={sort}
+                      setSelectedQuery={setSort}
+                    />
                   </div>
                 </div>
                 {sortedUsers && sortedUsers.length > 0 ? (

--- a/packages/frontend/src/pages/users/[userId].tsx
+++ b/packages/frontend/src/pages/users/[userId].tsx
@@ -8,6 +8,8 @@ import { PostWithReplies } from '@/components/post/PostWithReplies';
 import useError from '@/hooks/useError';
 import useName from '@/hooks/useName';
 import { IPostPreview, IUserUpvote } from '@/types/api';
+import { faArrowLeft } from '@fortawesome/free-solid-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { useQuery } from '@tanstack/react-query';
 import axios from 'axios';
 import { useRouter } from 'next/router';
@@ -76,14 +78,20 @@ export default function User() {
       <main className="flex w-full flex-col justify-center items-center">
         <div className="w-full bg-gray-50 flex flex-col justify-center items-center">
           <div className="bg-gray-50 min-h-screen w-full">
-            <div className="relative max-w-3xl mx-auto py-16 px-3 md:px-0">
-              <div className="absolute top-0 left-0 -translate-y-2/4 -translate-x-2/4">
+            <div className="relative max-w-3xl mx-auto py-16 px-6 md:px-0">
+              <div className="absolute top-0 left-4 -translate-y-2/4 md:-translate-x-2/4">
                 <div className="rounded-full w-[85px] h-[85px] bg-white flex items-center justify-center">
                   {userId && <UserAvatar userId={userId} width={75} />}
                 </div>
               </div>
-              {name && <h2 className="break-words">{name}</h2>}
-              <div className="flex flex-col gap-8 max-w-3xl mx-auto py-5 md:py-10 px-3 md:px-0">
+              <div className="flex flex-col gap-2">
+                <a className="flex gap-1 items-center hover:underline" href={'/users'}>
+                  <FontAwesomeIcon icon={faArrowLeft} className="secondary" />
+                  <p>All users</p>
+                </a>
+                {name && <h2 className="break-words">{name}</h2>}
+              </div>
+              <div className="flex flex-col gap-8 max-w-3xl mx-auto py-5 md:py-10">
                 {isLoading ? (
                   <Spinner />
                 ) : isError ? (

--- a/packages/frontend/src/pages/users/[userId].tsx
+++ b/packages/frontend/src/pages/users/[userId].tsx
@@ -1,4 +1,5 @@
 import { Header } from '@/components/Header';
+import { Modal } from '@/components/global/Modal';
 import { RetryError } from '@/components/global/RetryError';
 import Spinner from '@/components/global/Spinner';
 import { UserAvatar } from '@/components/global/UserAvatar';
@@ -62,14 +63,15 @@ export default function User() {
     <>
       <Header />
       {openPost ? (
-        <PostWithReplies
-          writerToShow={writerToShow}
-          postId={openPostId}
+        <Modal
+          startAtTop={true}
           handleClose={() => {
             router.replace('/', undefined, { shallow: true });
             setOpenPostId('');
           }}
-        />
+        >
+          <PostWithReplies writerToShow={writerToShow} postId={openPostId} />
+        </Modal>
       ) : null}
       <main className="flex w-full flex-col justify-center items-center">
         <div className="w-full bg-gray-50 flex flex-col justify-center items-center">

--- a/packages/frontend/src/pages/users/[userId].tsx
+++ b/packages/frontend/src/pages/users/[userId].tsx
@@ -82,7 +82,7 @@ export default function User() {
                   {userId && <UserAvatar userId={userId} width={75} />}
                 </div>
               </div>
-              {name && <h2>{name}</h2>}
+              {name && <h2 className="break-words">{name}</h2>}
               <div className="flex flex-col gap-8 max-w-3xl mx-auto py-5 md:py-10 px-3 md:px-0">
                 {isLoading ? (
                   <Spinner />

--- a/packages/frontend/src/pages/users/[userId].tsx
+++ b/packages/frontend/src/pages/users/[userId].tsx
@@ -9,13 +9,13 @@ import { PostWithReplies } from '@/components/post/PostWithReplies';
 import useError from '@/hooks/useError';
 import useName from '@/hooks/useName';
 import { IPostPreview, IUserUpvote } from '@/types/api';
+import { NameType } from '@/types/components';
 import { faArrowLeft } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { useQuery } from '@tanstack/react-query';
 import axios from 'axios';
 import { useRouter } from 'next/router';
 import { useMemo, useState } from 'react';
-import { isAddress } from 'viem';
 
 const getPostsByUserId = async (userId: string) =>
   (await axios.get<IPostPreview[]>(`/api/v1/users/${userId}/posts`)).data;
@@ -27,12 +27,11 @@ export default function User() {
   const router = useRouter();
   const { errorMsg, setError } = useError();
   const userId = router.query.userId as string;
-  const isDoxed = userId && isAddress(userId);
 
   const filterOptions: { [key: string]: string } = {
     all: 'All',
     posts: 'Posts',
-    replies: 'Replies',
+    replies: 'Comments',
   };
 
   // determine if post creator or replied to post (does post have a parent ID)
@@ -66,7 +65,7 @@ export default function User() {
     setOpenPostId(id);
   };
 
-  const { name } = useName({ userId });
+  const { name, isDoxed } = useName({ userId });
 
   return (
     <>
@@ -84,54 +83,58 @@ export default function User() {
       ) : null}
       <main className="flex w-full flex-col justify-center items-center">
         <div className="w-full bg-gray-50 flex flex-col justify-center items-center">
-          <div className="bg-gray-50 min-h-screen w-full">
-            <div className="relative max-w-3xl mx-auto py-16 px-6 md:px-0">
-              <div className="absolute top-0 left-4 -translate-y-2/4 md:-translate-x-2/4">
+          <div className="bg-gray-50 min-h-screen max-w-3xl mx-auto w-full p-6">
+            <div className="flex flex-col gap-4">
+              <a className="flex gap-1 items-center underline" href={'/users'}>
+                <FontAwesomeIcon icon={faArrowLeft} className="secondary" />
+                <p>All users</p>
+              </a>
+              <div className="flex gap-2 items-center">
                 <div className="rounded-full w-[85px] h-[85px] bg-white flex items-center justify-center">
-                  {userId && <UserAvatar userId={userId} width={75} />}
-                </div>
-              </div>
-              <div className="flex flex-col gap-2">
-                <a className="flex gap-1 items-center hover:underline" href={'/users'}>
-                  <FontAwesomeIcon icon={faArrowLeft} className="secondary" />
-                  <p>All users</p>
-                </a>
-                {name && <h2 className="break-words">{name}</h2>}
-              </div>
-
-              <div className="flex flex-col gap-8 max-w-3xl mx-auto py-5 md:py-10">
-                {isLoading ? (
-                  <Spinner />
-                ) : isError ? (
-                  <RetryError
-                    message="Could not fetch user data."
-                    error={errorMsg}
-                    refetchHandler={refetch}
-                  />
-                ) : userPosts ? (
-                  <>
-                    <Filters
-                      filters={filterOptions}
-                      selectedFilter={'all'}
-                      setSelectedFilter={() => console.log('select this one')}
+                  {userId && (
+                    <UserAvatar
+                      type={isDoxed ? NameType.DOXED : NameType.PSEUDO}
+                      userId={userId}
+                      width={75}
                     />
-                    {userPosts.map((post) => (
-                      <PostPreview
-                        showUserHeader={true}
-                        key={post.id}
-                        {...post}
-                        handleOpenPost={(writerToShow: string) => {
-                          router.replace(window.location.href, `/posts/${post.id}`, {
-                            shallow: true,
-                          });
-                          handleOpenPost(post.id, writerToShow);
-                        }}
-                        onSuccess={() => console.log('need to refetch here')}
-                      />
-                    ))}
-                  </>
-                ) : null}
+                  )}
+                </div>
+                {name && <h2 className="break-words breakText">{name}</h2>}
               </div>
+            </div>
+
+            <div className="flex flex-col gap-8 max-w-3xl mx-auto py-5 md:py-10">
+              {isLoading ? (
+                <Spinner />
+              ) : isError ? (
+                <RetryError
+                  message="Could not fetch user data."
+                  error={errorMsg}
+                  refetchHandler={refetch}
+                />
+              ) : userPosts ? (
+                <>
+                  <Filters
+                    filters={filterOptions}
+                    selectedFilter={'all'}
+                    setSelectedFilter={() => console.log('select this one')}
+                  />
+                  {userPosts.map((post) => (
+                    <PostPreview
+                      showUserHeader={true}
+                      key={post.id}
+                      {...post}
+                      handleOpenPost={(writerToShow: string) => {
+                        router.replace(window.location.href, `/posts/${post.id}`, {
+                          shallow: true,
+                        });
+                        handleOpenPost(post.id, writerToShow);
+                      }}
+                      onSuccess={() => console.log('need to refetch here')}
+                    />
+                  ))}
+                </>
+              ) : null}
             </div>
           </div>
         </div>

--- a/packages/frontend/src/pages/users/[userId].tsx
+++ b/packages/frontend/src/pages/users/[userId].tsx
@@ -3,6 +3,7 @@ import { Modal } from '@/components/global/Modal';
 import { RetryError } from '@/components/global/RetryError';
 import Spinner from '@/components/global/Spinner';
 import { UserAvatar } from '@/components/global/UserAvatar';
+import { Filters } from '@/components/post/Filters';
 import { PostPreview } from '@/components/post/PostPreview';
 import { PostWithReplies } from '@/components/post/PostWithReplies';
 import useError from '@/hooks/useError';
@@ -27,6 +28,12 @@ export default function User() {
   const { errorMsg, setError } = useError();
   const userId = router.query.userId as string;
   const isDoxed = userId && isAddress(userId);
+
+  const filterOptions: { [key: string]: string } = {
+    all: 'All',
+    posts: 'Posts',
+    replies: 'Replies',
+  };
 
   // determine if post creator or replied to post (does post have a parent ID)
   const {
@@ -91,6 +98,7 @@ export default function User() {
                 </a>
                 {name && <h2 className="break-words">{name}</h2>}
               </div>
+
               <div className="flex flex-col gap-8 max-w-3xl mx-auto py-5 md:py-10">
                 {isLoading ? (
                   <Spinner />
@@ -101,20 +109,27 @@ export default function User() {
                     refetchHandler={refetch}
                   />
                 ) : userPosts ? (
-                  userPosts.map((post) => (
-                    <PostPreview
-                      showUserHeader={true}
-                      key={post.id}
-                      {...post}
-                      handleOpenPost={(writerToShow: string) => {
-                        router.replace(window.location.href, `/posts/${post.id}`, {
-                          shallow: true,
-                        });
-                        handleOpenPost(post.id, writerToShow);
-                      }}
-                      onSuccess={() => console.log('need to refetch here')}
+                  <>
+                    <Filters
+                      filters={filterOptions}
+                      selectedFilter={'all'}
+                      setSelectedFilter={() => console.log('select this one')}
                     />
-                  ))
+                    {userPosts.map((post) => (
+                      <PostPreview
+                        showUserHeader={true}
+                        key={post.id}
+                        {...post}
+                        handleOpenPost={(writerToShow: string) => {
+                          router.replace(window.location.href, `/posts/${post.id}`, {
+                            shallow: true,
+                          });
+                          handleOpenPost(post.id, writerToShow);
+                        }}
+                        onSuccess={() => console.log('need to refetch here')}
+                      />
+                    ))}
+                  </>
                 ) : null}
               </div>
             </div>

--- a/packages/frontend/src/styles/globals.css
+++ b/packages/frontend/src/styles/globals.css
@@ -67,6 +67,11 @@
     box-sizing: border-box;
   }
 
+  select {
+    appearance: none;
+    -webkit-appearance: none;
+  }
+
   /* Comment Writer Styles */
   textarea,
   pre {

--- a/packages/frontend/src/styles/globals.css
+++ b/packages/frontend/src/styles/globals.css
@@ -99,6 +99,12 @@
     color: #0e76fd;
   }
 
+  .breakText {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
   .dot1 {
     animation: visibility 1s linear infinite;
   }

--- a/packages/frontend/types/components/index.ts
+++ b/packages/frontend/types/components/index.ts
@@ -11,7 +11,6 @@ export type PostProps = IPostPreview & {
 export type PostWithRepliesProps = {
   postId: string;
   writerToShow?: string;
-  handleClose: () => void;
 };
 
 export type LocalNym = {
@@ -51,6 +50,7 @@ export type ContentUserInput = {
 };
 
 export type UserContextType = {
+  isMobile: boolean;
   nymOptions: ClientName[];
   setNymOptions: Dispatch<SetStateAction<ClientName[]>>;
   isValid: boolean;


### PR DESCRIPTION
### Mobile Design
- [x] Replace `PostWithReplies` modal with new page
- [x] Mobile header / hamburger menu (still need to flesh out designs for this)
- [x] Warning modals become slideUps
> - [ ] Add slideUp transitions
- [x] Simplify post previews
- [x] Loading spinner when click on post preview
- [x] Better avatar UI in menu
- [x] Hide excess info on RainbowConnectKit button

#### Implementation Notes:
- Used tailwind media queries when possible
- Conditional template rendering uses a `UserContext` attribute `isMobile`

### Filter Fixes
- Fix `lastActive` filter on users page
- Added `Top` and `Recent` filters to the posts page
- Added `Posts` and `Replies` filters to the [userId] page (WIP)