### PR TITLE
feat(wip): basic cache control

### DIFF
--- a/packages/frontend/src/components/Header.tsx
+++ b/packages/frontend/src/components/Header.tsx
@@ -20,7 +20,7 @@ export const Header = () => {
           </div>
         </nav>
         <div className="grow flex justify-center">
-          <Image className="w-[150px]" src="/nouns.png" alt="nouns" />
+          <Image src="/nouns.png" alt="nouns" width={150} height={150} />
         </div>
       </div>
     </div>

--- a/packages/frontend/src/components/Header.tsx
+++ b/packages/frontend/src/components/Header.tsx
@@ -20,8 +20,7 @@ export const Header = () => {
           </div>
         </nav>
         <div className="grow flex justify-center">
-          {/* eslint-disable-next-line @next/next/no-img-element */}
-          <img className="w-[150px]" src="/nouns.png" alt="nouns" />
+          <Image className="w-[150px]" src="/nouns.png" alt="nouns" />
         </div>
       </div>
     </div>

--- a/packages/frontend/src/components/Posts.tsx
+++ b/packages/frontend/src/components/Posts.tsx
@@ -4,7 +4,7 @@ import axios from 'axios';
 import { IPostPreview } from '@/types/api';
 import Spinner from './global/Spinner';
 import { MainButton } from './MainButton';
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import { NewPost } from './userInput/NewPost';
 import { Upvote } from './Upvote';
 import { PostWithReplies } from './post/PostWithReplies';
@@ -17,10 +17,11 @@ const getPosts = async () => (await axios.get<IPostPreview[]>('/api/v1/posts')).
 
 interface PostsProps {
   initOpenPostId?: string;
+  posts?: IPostPreview[];
 }
 
 export default function Posts(props: PostsProps) {
-  const { initOpenPostId } = props;
+  const { initOpenPostId, posts } = props;
   const { errorMsg, setError } = useError();
   const router = useRouter();
 
@@ -28,7 +29,7 @@ export default function Posts(props: PostsProps) {
     isLoading,
     isError,
     refetch,
-    data: posts,
+    data: currPosts,
   } = useQuery<IPostPreview[]>({
     queryKey: ['posts'],
     queryFn: getPosts,
@@ -41,6 +42,8 @@ export default function Posts(props: PostsProps) {
       setError(error);
     },
   });
+
+  const data = useMemo(() => currPosts || posts, [currPosts, posts]);
 
   const refetchAndScrollToPost = async (postId?: string) => {
     await refetch();
@@ -86,9 +89,9 @@ export default function Posts(props: PostsProps) {
                 <>
                   <Spinner />
                 </>
-              ) : posts ? (
+              ) : data ? (
                 <>
-                  {posts.map((post) => (
+                  {data.map((post) => (
                     <div className="flex gap-2" key={post.id}>
                       <Upvote
                         upvotes={post.upvotes}

--- a/packages/frontend/src/pages/api/v1/posts.ts
+++ b/packages/frontend/src/pages/api/v1/posts.ts
@@ -45,7 +45,7 @@ const handleGetPosts = async (req: NextApiRequest, res: NextApiResponse<IPostPre
   const take = req.query.limit ? parseInt(req.query.limit as string) : 10;
 
   const posts = await selectAndCleanPosts(undefined, skip, take);
-  res.setHeader('Cache-Control', 's-maxage=21600');
+  res.setHeader('Cache-Control', 's-maxage=1, stale-while-revalidate');
   res.send(posts);
 };
 

--- a/packages/frontend/src/pages/api/v1/posts.ts
+++ b/packages/frontend/src/pages/api/v1/posts.ts
@@ -45,6 +45,7 @@ const handleGetPosts = async (req: NextApiRequest, res: NextApiResponse<IPostPre
   const take = req.query.limit ? parseInt(req.query.limit as string) : 10;
 
   const posts = await selectAndCleanPosts(undefined, skip, take);
+  res.setHeader('Cache-Control', 's-maxage=21600');
   res.send(posts);
 };
 

--- a/packages/frontend/src/pages/api/v1/posts.ts
+++ b/packages/frontend/src/pages/api/v1/posts.ts
@@ -45,7 +45,6 @@ const handleGetPosts = async (req: NextApiRequest, res: NextApiResponse<IPostPre
   const take = req.query.limit ? parseInt(req.query.limit as string) : 10;
 
   const posts = await selectAndCleanPosts(undefined, skip, take);
-  res.setHeader('Cache-Control', 's-maxage=1, stale-while-revalidate');
   res.send(posts);
 };
 

--- a/packages/frontend/src/pages/index.tsx
+++ b/packages/frontend/src/pages/index.tsx
@@ -1,10 +1,18 @@
 import Posts from '@/components/Posts';
+import { IPostPreview } from '@/types/api';
 import { ErrorBoundary } from 'react-error-boundary';
+import { selectAndCleanPosts } from './api/v1/utils';
 
-export default function Home() {
+export async function getServerSideProps(): Promise<{ props: { posts: IPostPreview[] | null } }> {
+  const posts = await selectAndCleanPosts(undefined, 0, 10);
+  console.log(`posts`, posts);
+  return { props: { posts: JSON.parse(JSON.stringify(posts)) } };
+}
+
+export default function Home({ posts }: { posts?: IPostPreview[] }) {
   return (
     <ErrorBoundary fallback={<div>Top level error</div>}>
-      <Posts />
+      <Posts posts={posts} />
     </ErrorBoundary>
   );
 }

--- a/packages/frontend/src/pages/index.tsx
+++ b/packages/frontend/src/pages/index.tsx
@@ -5,7 +5,6 @@ import { selectAndCleanPosts } from './api/v1/utils';
 
 export async function getStaticProps(): Promise<{ props: { posts: IPostPreview[] | null } }> {
   const posts = await selectAndCleanPosts(undefined, 0, 10);
-  console.log(`posts`, posts);
   return { props: { posts: JSON.parse(JSON.stringify(posts)) } };
 }
 

--- a/packages/frontend/src/pages/index.tsx
+++ b/packages/frontend/src/pages/index.tsx
@@ -3,7 +3,7 @@ import { IPostPreview } from '@/types/api';
 import { ErrorBoundary } from 'react-error-boundary';
 import { selectAndCleanPosts } from './api/v1/utils';
 
-export async function getServerSideProps(): Promise<{ props: { posts: IPostPreview[] | null } }> {
+export async function getStaticProps(): Promise<{ props: { posts: IPostPreview[] | null } }> {
   const posts = await selectAndCleanPosts(undefined, 0, 10);
   console.log(`posts`, posts);
   return { props: { posts: JSON.parse(JSON.stringify(posts)) } };


### PR DESCRIPTION
Closing because I have this document: https://www.notion.so/personae-labs/Performance-Optimization-37df905265314ce19fb213f9c9956d68?pvs=4

afaict, caching doens't help this problem of slow initial response times. I also haven't been able to find a satisfying schema for caching the initial response, but not refetches. Will revisit.