### PR TITLE
[READY FOR REVIEW] Support deep-linking with new threading

### DIFF
--- a/packages/frontend/public/api-doc.yml
+++ b/packages/frontend/public/api-doc.yml
@@ -80,6 +80,19 @@ paths:
       responses:
         '200':
           description: OK
+  /posts/{postId}/fetchParents:
+    get:
+      description: Fetch all parent responses with the last descendant as post with {postId}
+      operationId: getPost
+      parameters:
+        - name: postId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: OK
   /posts/{postId}/upvote:
     post:
       description: Get a single post and all of its children

--- a/packages/frontend/src/components/post/PostWithReplies.tsx
+++ b/packages/frontend/src/components/post/PostWithReplies.tsx
@@ -87,6 +87,32 @@ export const PostWithReplies = (postWithRepliesProps: PostWithRepliesProps) => {
     }
   }, [isSuccess, singlePost]);
 
+  const recursivelyFindPostId = (idLookFor: string, path: string[], data?: IPostWithReplies) => {
+    if (data) {
+      const replies = data.replies;
+
+      for (let i = 0; i < replies.length; i++) {
+        const reply = replies[i];
+        const newPath = [...path, reply.id];
+
+        if (reply.id === idLookFor) {
+          const newPostsVisibility = { ...postsVisibilityMap };
+
+          for (const element of path) {
+            newPostsVisibility[element] = 1;
+          }
+
+          newPostsVisibility[idLookFor] = 1;
+          setPostsVisibilityMap(newPostsVisibility);
+        } else {
+          recursivelyFindPostId(idLookFor, newPath, reply);
+        }
+      }
+    } else {
+      //TODO: need to handle fetching deepr logic
+    }
+  };
+
   // to make sure top-level comments always load when the component is mounted
   useEffect(() => {
     const newPostsVisibility = { ...postsVisibilityMap };
@@ -100,6 +126,14 @@ export const PostWithReplies = (postWithRepliesProps: PostWithRepliesProps) => {
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [combinedData]);
+
+  useEffect(() => {
+    // if postId is defined in postWithRepliesProps, navigate postsVisibilityMap and set the post to be visible
+    if (postWithRepliesProps.postId) {
+      recursivelyFindPostId(postWithRepliesProps.postId, [combinedData?.id || ''], combinedData);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [combinedData, postWithRepliesProps.postId]);
 
   useEffect(() => {
     const data = combinedData ? _.cloneDeep(combinedData) : _.cloneDeep(singlePost);

--- a/packages/frontend/src/components/post/PostWithReplies.tsx
+++ b/packages/frontend/src/components/post/PostWithReplies.tsx
@@ -97,16 +97,19 @@ export const PostWithReplies = (postWithRepliesProps: PostWithRepliesProps) => {
     if (data) {
       const replies = data.replies;
 
-      // don't mess with top-level comments which we have another useEffect for loading
-      if (data.id === idLookFor && depth > 1) {
-        const newPostsVisibility = { ...postsVisibilityMap };
+      if (data.id === idLookFor) {
+        // don't mess with top-level comments which we have another useEffect for loading
+        if (depth > 1) {
+          const newPostsVisibility = { ...postsVisibilityMap };
 
-        for (const element of path) {
-          newPostsVisibility[element] = 1;
+          for (const element of path) {
+            newPostsVisibility[element] = 1;
+          }
+
+          newPostsVisibility[idLookFor] = 1;
+          setPostsVisibilityMap(newPostsVisibility);
         }
-
-        newPostsVisibility[idLookFor] = 1;
-        setPostsVisibilityMap(newPostsVisibility);
+        return true;
       }
 
       if (data.replies) {
@@ -191,17 +194,17 @@ export const PostWithReplies = (postWithRepliesProps: PostWithRepliesProps) => {
       );
 
       // if not found query the api at api/v1/posts/postId/fetchParents
-      // if (!foundPostWithId) {
-      //   console.log('combined: ', combinedData);
-      //   console.log('querying post parents');
-      //   const fetchPost = async () => {
-      //     const newResult = await axios.get(
-      //       '/api/v1/posts/' + postWithRepliesProps.postId + '/fetchParents',
-      //     );
-      //     setCombinedData(newResult.data);
-      //   };
-      //   fetchPost();
-      // }
+      if (!foundPostWithId) {
+        console.log('did not find, need to query fetchParents');
+        console.log(postWithRepliesProps.postId, combinedData);
+        const fetchPost = async () => {
+          const newResult = await axios.get(
+            '/api/v1/posts/' + postWithRepliesProps.postId + '/fetchParents',
+          );
+          setCombinedData(newResult.data);
+        };
+        fetchPost();
+      }
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [combinedData, postWithRepliesProps.postId]);

--- a/packages/frontend/src/components/post/PostWithReplies.tsx
+++ b/packages/frontend/src/components/post/PostWithReplies.tsx
@@ -133,7 +133,7 @@ export const PostWithReplies = (postWithRepliesProps: PostWithRepliesProps) => {
       combinedData.replies.forEach((reply) => {
         newPostsVisibility[reply.id] = 1;
       });
-      console.log('set from combined data');
+
       setPostsVisibilityMap(newPostsVisibility);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -195,14 +195,13 @@ export const PostWithReplies = (postWithRepliesProps: PostWithRepliesProps) => {
 
       // if not found query the api at api/v1/posts/postId/fetchParents
       if (!foundPostWithId) {
-        console.log('did not find, need to query fetchParents');
-        console.log(postWithRepliesProps.postId, combinedData);
         const fetchPost = async () => {
           const newResult = await axios.get(
             '/api/v1/posts/' + postWithRepliesProps.postId + '/fetchParents',
           );
           setCombinedData(newResult.data);
         };
+
         fetchPost();
       }
     }

--- a/packages/frontend/src/pages/api/v1/posts/[postId]/fetchParents.ts
+++ b/packages/frontend/src/pages/api/v1/posts/[postId]/fetchParents.ts
@@ -1,11 +1,15 @@
 import prisma from '@/lib/prisma';
-import { all } from 'axios';
 import type { NextApiRequest, NextApiResponse } from 'next';
 
 // Handle non-pseudonymous upvotes
 // Verify the ECDSA signature and save the upvote
 const fetchParents = async (req: NextApiRequest, res: NextApiResponse<{} | { error: string }>) => {
   const postId = req.query.postId as string;
+
+  if (!postId) {
+    res.status(400).send({ error: 'PostId is required' });
+    return;
+  }
 
   let newPost = await prisma.post.findUnique({
     where: {

--- a/packages/frontend/src/pages/api/v1/posts/[postId]/fetchParents.ts
+++ b/packages/frontend/src/pages/api/v1/posts/[postId]/fetchParents.ts
@@ -13,6 +13,7 @@ const fetchParents = async (req: NextApiRequest, res: NextApiResponse<{} | { err
     },
     include: {
       parent: true,
+      upvotes: true,
     },
   });
 
@@ -29,6 +30,7 @@ const fetchParents = async (req: NextApiRequest, res: NextApiResponse<{} | { err
           },
           include: {
             parent: true,
+            upvotes: true,
           },
         });
         if (newPost) {

--- a/packages/frontend/src/pages/api/v1/posts/[postId]/fetchParents.ts
+++ b/packages/frontend/src/pages/api/v1/posts/[postId]/fetchParents.ts
@@ -1,0 +1,63 @@
+import prisma from '@/lib/prisma';
+import { all } from 'axios';
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+// Handle non-pseudonymous upvotes
+// Verify the ECDSA signature and save the upvote
+const fetchParents = async (req: NextApiRequest, res: NextApiResponse<{} | { error: string }>) => {
+  const postId = req.query.postId as string;
+
+  let newPost = await prisma.post.findUnique({
+    where: {
+      id: postId,
+    },
+    include: {
+      parent: true,
+    },
+  });
+
+  if (newPost) {
+    const allPosts = [newPost];
+
+    // fetch all parents of postId
+    while (newPost) {
+      // make a db query to fetch the currentPost
+      if (newPost.parentId) {
+        newPost = await prisma.post.findUnique({
+          where: {
+            id: newPost.parentId,
+          },
+          include: {
+            parent: true,
+          },
+        });
+        if (newPost) {
+          allPosts.push(newPost);
+        }
+      } else {
+        newPost = null;
+      }
+    }
+
+    // construct finaPostTree by iterating over allPosts in reverse order and setting the replies of each post to the previous post
+    for (let i = allPosts.length - 1; i > 0; i--) {
+      // @ts-ignore
+      allPosts[i].replies = [allPosts[i - 1]];
+    }
+
+    // @ts-ignore
+    allPosts[0].replies = [];
+
+    res.status(200).send(allPosts[allPosts.length - 1]);
+  } else {
+    res.status(400).send({ error: 'Post could not be found' });
+  }
+};
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method == 'GET') {
+    await fetchParents(req, res);
+  } else {
+    res.status(400).send('Unsupported method');
+  }
+}


### PR DESCRIPTION
This PR adds support for deep-linking posts in all threads including
- comment threads which are available client-side (i.e. <5 depth on initial load)
- comments threads which are deeper than depth 5 and are not returned in the first server load data (so we need to go out and fetch it)

Demo:
https://drive.google.com/file/d/1JsMdEb1V3_3J39VMeuWXjvNZm_YhSI3Q/view?usp=drive_link