### PR TITLE
Remove `close()` calls on name selection

### DIFF
--- a/packages/frontend/src/components/userInput/NameSelect.tsx
+++ b/packages/frontend/src/components/userInput/NameSelect.tsx
@@ -79,7 +79,6 @@ export const NameSelect = (props: NameSelectProps) => {
                       className="w-full flex justify-between gap-2 px-2 py-2.5 rounded-xl hover:bg-gray-100"
                       onClick={() => {
                         setSelectedName(nym);
-                        close();
                       }}
                     >
                       <NameMenuItem
@@ -96,7 +95,6 @@ export const NameSelect = (props: NameSelectProps) => {
                 className="w-full flex justify-between gap-2 items-center px-2 py-2.5 rounded-xl hover:bg-gray-100"
                 onClick={() => {
                   setSelectedName(doxedName);
-                  close();
                 }}
               >
                 <NameMenuItem


### PR DESCRIPTION
Fixes the bug that closes the tab when you select an identity.

@grace-fagan 
Not sure why `close` was there, but lmk if there're contexts I'm missing.
