### PR TITLE
Notifications again

### DIFF
--- a/packages/frontend/src/components/Header.tsx
+++ b/packages/frontend/src/components/Header.tsx
@@ -2,7 +2,7 @@ import ConnectWallet from './ConnectWallet';
 import logo from '../../public/logo.svg';
 import { MyProfile } from './MyProfile';
 import Image from 'next/image';
-import { useContext } from 'react';
+import { useContext, useEffect, useState } from 'react';
 import { UserContext } from '@/pages/_app';
 import { UserContextType } from '@/types/components';
 import { useAccount } from 'wagmi';
@@ -11,6 +11,13 @@ import { Notifications } from './notifications/Notifications';
 export const Header = () => {
   const { address } = useAccount();
   const { isMobile, isValid, pushRoute } = useContext(UserContext) as UserContextType;
+
+  const [localAddress, setLocalAddress] = useState('');
+
+  useEffect(() => {
+    // Prevents server side mismatch with address. Idk why
+    if (address) setLocalAddress(address);
+  }, [address]);
 
   return (
     <>
@@ -35,9 +42,9 @@ export const Header = () => {
               </p>
             </div>
             <div className="flex gap-4 items-center">
-              {address && isValid && <Notifications />}
-              {(!isMobile || !address || !isValid) && <ConnectWallet />}
-              <MyProfile />
+              {localAddress && isValid && <Notifications />}
+              {(!isMobile || !localAddress || !isValid) && <ConnectWallet />}
+              <MyProfile address={localAddress} />
             </div>
           </nav>
           {!isMobile && (

--- a/packages/frontend/src/components/MyProfile.tsx
+++ b/packages/frontend/src/components/MyProfile.tsx
@@ -3,35 +3,26 @@ import { useContext, useEffect, useState } from 'react';
 import { NameType, UserContextType } from '@/types/components';
 import useName from '@/hooks/useName';
 import { UserContext } from '@/pages/_app';
-import { useAccount } from 'wagmi';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faAngleDown, faUser } from '@fortawesome/free-solid-svg-icons';
 import ConnectWallet from './ConnectWallet';
 import { Menu } from '@headlessui/react';
 import { getUserIdFromName } from '@/lib/example-utils';
 
-export const MyProfile = () => {
-  const { address } = useAccount();
+export const MyProfile = ({ address }: { address: string }) => {
   const { isMobile, nymOptions, isValid, pushRoute } = useContext(UserContext) as UserContextType;
   const { name } = useName({ userId: address });
 
-  const [localAddress, setLocalAddress] = useState('');
-
-  useEffect(() => {
-    // Prevents server side mismatch with address. Idk why
-    if (address) setLocalAddress(address);
-  }, [address]);
-
   return (
     <>
-      {localAddress && isValid ? (
+      {address && isValid ? (
         <Menu as={'div'} className="relative cursor-pointer">
           <Menu.Button className="flex items-center gap-2 rounded-xl px-2 py-1 border border-white hover:scale-105 active:scale-100 transition-all">
-            <UserAvatar width={30} userId={localAddress} />
+            <UserAvatar width={30} userId={address} />
             <FontAwesomeIcon icon={faAngleDown} color="#ffffff" />
           </Menu.Button>
           <Menu.Items className="max-w-[150px] absolute top-full right-0 bg-white mt-2 border border-gray-200 rounded-xl cursor-pointer">
-            {isMobile && localAddress && isValid && (
+            {isMobile && address && isValid && (
               <>
                 <p className="secondary p-2">Wallet</p>
                 <Menu.Item disabled as={'div'} className="w-full flex justify-center">
@@ -44,9 +35,9 @@ export const MyProfile = () => {
               <Menu.Item
                 as={'div'}
                 className="min-w-0 shrink w-full flex items-center gap-2 px-2 py-2.5 rounded-xl hover:bg-gray-100"
-                onClick={() => pushRoute(`/users/${localAddress}`)}
+                onClick={() => pushRoute(`/users/${address}`)}
               >
-                <UserAvatar type={NameType.DOXED} userId={localAddress} width={20} />
+                <UserAvatar type={NameType.DOXED} userId={address} width={20} />
                 <p className="breakText">{name}</p>
               </Menu.Item>
               {nymOptions &&

--- a/packages/frontend/src/components/global/Providers.tsx
+++ b/packages/frontend/src/components/global/Providers.tsx
@@ -1,15 +1,10 @@
-import { QueryClientProvider, QueryClient } from '@tanstack/react-query';
-
-const queryClient = new QueryClient();
-
-import { RainbowKitProvider, getDefaultWallets } from '@rainbow-me/rainbowkit';
+import { RainbowKitProvider } from '@rainbow-me/rainbowkit';
 import '@rainbow-me/rainbowkit/styles.css';
-
 import { configureChains } from 'wagmi';
-import { mainnet, polygon, optimism } from 'wagmi/chains';
+import { mainnet } from 'wagmi/chains';
 import { publicProvider } from 'wagmi/providers/public';
 
-const { chains } = configureChains([mainnet, polygon, optimism], [publicProvider()]);
+const { chains } = configureChains([mainnet], [publicProvider()]);
 
 export default function RainbowProviders({ children }: { children: any }) {
   return <RainbowKitProvider chains={chains}>{children}</RainbowKitProvider>;

--- a/packages/frontend/src/components/notifications/Notifications.tsx
+++ b/packages/frontend/src/components/notifications/Notifications.tsx
@@ -6,7 +6,7 @@ import {
   setNotificationsInLocalStorage,
 } from '@/hooks/useNotifications';
 import { Menu } from '@headlessui/react';
-import { UserContextType, Notification } from '@/types/components';
+import { Notification } from '@/types/api';
 import Spinner from '../global/Spinner';
 import { useAccount } from 'wagmi';
 import { useContext, useMemo, useState } from 'react';
@@ -14,6 +14,7 @@ import { UserContext } from '@/pages/_app';
 import { Filters } from '../post/Filters';
 import { SingleNotification } from './SingleNotification';
 import { RefreshNotifications } from './RefreshNotifications';
+import { UserContextType } from '@/types/components';
 
 export const setNotificationAsRead = (
   address: string,
@@ -129,7 +130,7 @@ export const Notifications = () => {
                               setNotifications,
                               n.id,
                             );
-                            pushRoute(`/posts/${n.id}`);
+                            pushRoute(`/posts/${n.postId}`);
                           }}
                         >
                           <SingleNotification n={n} />

--- a/packages/frontend/src/components/notifications/Notifications.tsx
+++ b/packages/frontend/src/components/notifications/Notifications.tsx
@@ -2,7 +2,6 @@ import { faBell, faCheck, faRefresh, faXmark } from '@fortawesome/free-solid-svg
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { useNotifications } from '@/hooks/useNotifications';
 import { Menu } from '@headlessui/react';
-import { Notification } from '@/types/notifications';
 import Spinner from '../global/Spinner';
 import { useAccount } from 'wagmi';
 import { useContext, useMemo, useState } from 'react';
@@ -15,10 +14,7 @@ import { UserContextType } from '@/types/components';
 export const Notifications = () => {
   const { address } = useAccount();
   const { isMobile, nymOptions, pushRoute } = useContext(UserContext) as UserContextType;
-  const { notifications, unread, setNotifications, setNotificationsAsRead, isLoading } =
-    useNotifications({
-      enabled: true,
-    });
+  const { notifications, unread, isLoading, setNotificationsAsRead } = useNotifications();
   const [filter, setFilter] = useState('all');
 
   const notificationsToShow = useMemo(

--- a/packages/frontend/src/components/notifications/Notifications.tsx
+++ b/packages/frontend/src/components/notifications/Notifications.tsx
@@ -1,12 +1,8 @@
 import { faBell, faCheck, faRefresh, faXmark } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import {
-  useNotifications,
-  notificationsListToMap,
-  setNotificationsInLocalStorage,
-} from '@/hooks/useNotifications';
+import { useNotifications } from '@/hooks/useNotifications';
 import { Menu } from '@headlessui/react';
-import { Notification } from '@/types/api';
+import { Notification } from '@/types/notifications';
 import Spinner from '../global/Spinner';
 import { useAccount } from 'wagmi';
 import { useContext, useMemo, useState } from 'react';
@@ -16,53 +12,19 @@ import { SingleNotification } from './SingleNotification';
 import { RefreshNotifications } from './RefreshNotifications';
 import { UserContextType } from '@/types/components';
 
-export const setNotificationAsRead = (
-  address: string,
-  notifications: Notification[] | undefined,
-  setNotifications: (n: Notification[]) => void,
-  id: string,
-) => {
-  if (notifications) {
-    // update notifications in memory
-    const newNotifications = notifications.map((n) => {
-      if (n.id === id) return { ...n, read: true };
-      return n;
-    });
-    setNotifications(newNotifications);
-    const map = notificationsListToMap(newNotifications);
-    // write new map to local storage
-    setNotificationsInLocalStorage(address, map);
-  }
-};
-
-export const MarkAllAsRead = (
-  address: string,
-  notifications: Notification[] | undefined,
-  setNotifications: (n: Notification[]) => void,
-) => {
-  if (notifications) {
-    // update notifications in memory
-    const newNotifications = notifications.map((n) => {
-      return { ...n, read: true };
-    });
-    setNotifications(newNotifications);
-    const map = notificationsListToMap(newNotifications);
-    // write new map to local storage
-    setNotificationsInLocalStorage(address, map);
-  }
-};
-
 export const Notifications = () => {
   const { address } = useAccount();
   const { isMobile, nymOptions, pushRoute } = useContext(UserContext) as UserContextType;
-  const { notifications, unreadNotifications, setNotifications, isLoading } = useNotifications({
-    enabled: true,
-  });
+  const { notifications, unread, setNotifications, setNotificationsAsRead, isLoading } =
+    useNotifications({
+      enabled: true,
+    });
   const [filter, setFilter] = useState('all');
 
   const notificationsToShow = useMemo(
-    () => (filter === 'unread' ? unreadNotifications : notifications)?.slice(0, 5),
-    [filter, notifications, unreadNotifications],
+    () =>
+      (filter === 'unread' ? notifications?.filter((n) => !n.read) : notifications)?.slice(0, 5),
+    [filter, notifications],
   );
 
   const filters = {
@@ -82,7 +44,7 @@ export const Notifications = () => {
               }}
             >
               <FontAwesomeIcon icon={faBell} size={'2xl'} color={'#ffffff'} />
-              {unreadNotifications.length > 0 && (
+              {unread.length > 0 && (
                 <div className="absolute bottom-full left-full translate-y-3/4 -translate-x-3/4 rounded-full w-4 h-4 bg-red-700" />
               )}
             </Menu.Button>
@@ -104,9 +66,7 @@ export const Notifications = () => {
                     />
                     <div
                       className="flex gap-1 justify-end items-center"
-                      onClick={() =>
-                        MarkAllAsRead(address as string, notifications, setNotifications)
-                      }
+                      onClick={() => setNotificationsAsRead(address, '', true)}
                     >
                       <FontAwesomeIcon icon={faCheck} size={'xs'} />
                       <p className="secondary hover:underline">Mark all as read</p>
@@ -124,12 +84,7 @@ export const Notifications = () => {
                             n.read ? 'bg-white' : 'bg-gray-100'
                           }`}
                           onClick={() => {
-                            setNotificationAsRead(
-                              address as string,
-                              notifications,
-                              setNotifications,
-                              n.id,
-                            );
+                            setNotificationsAsRead(address, n.id);
                             pushRoute(`/posts/${n.postId}`);
                           }}
                         >

--- a/packages/frontend/src/components/notifications/RefreshNotifications.tsx
+++ b/packages/frontend/src/components/notifications/RefreshNotifications.tsx
@@ -9,7 +9,7 @@ import { ClientName } from '@/types/components';
 export const RefreshNotifications = (props: { nymOptions: ClientName[] }) => {
   const { nymOptions } = props;
   const { address } = useAccount();
-  const { fetchNotifications } = useNotifications({ enabled: true });
+  const { fetchNotifications } = useNotifications();
   const [refetching, setRefetching] = useState(false);
 
   const refetch = async () => {

--- a/packages/frontend/src/components/notifications/RefreshNotifications.tsx
+++ b/packages/frontend/src/components/notifications/RefreshNotifications.tsx
@@ -13,9 +13,11 @@ export const RefreshNotifications = (props: { nymOptions: ClientName[] }) => {
   const [refetching, setRefetching] = useState(false);
 
   const refetch = async () => {
-    setRefetching(true);
-    await fetchNotifications(address as string, nymOptions);
-    setRefetching(false);
+    if (address) {
+      setRefetching(true);
+      await fetchNotifications(address, nymOptions);
+      setRefetching(false);
+    }
   };
   return (
     <div className="cursor-pointer">

--- a/packages/frontend/src/components/notifications/SingleNotification.tsx
+++ b/packages/frontend/src/components/notifications/SingleNotification.tsx
@@ -1,6 +1,6 @@
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { UserAvatar } from '../global/UserAvatar';
-import { NotificationType, Notification } from '@/types/components';
+import { NotificationType, Notification } from '@/types/api';
 import { faCircleUp, faReply, faReplyAll } from '@fortawesome/free-solid-svg-icons';
 import { UserName } from '../global/UserName';
 import { fromNowDate } from '@/lib/example-utils';

--- a/packages/frontend/src/components/notifications/SingleNotification.tsx
+++ b/packages/frontend/src/components/notifications/SingleNotification.tsx
@@ -1,9 +1,9 @@
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { UserAvatar } from '../global/UserAvatar';
-import { NotificationType, Notification } from '@/types/api';
 import { faCircleUp, faReply, faReplyAll } from '@fortawesome/free-solid-svg-icons';
 import { UserName } from '../global/UserName';
 import { fromNowDate } from '@/lib/example-utils';
+import { NotificationType, Notification } from '@/types/notifications';
 
 const getNotificationFromType = (type: NotificationType) => {
   switch (type) {

--- a/packages/frontend/src/hooks/useNotifications.ts
+++ b/packages/frontend/src/hooks/useNotifications.ts
@@ -104,7 +104,7 @@ const buildNotifications = (raw: RawNotifications, myIds: string[]): Notificatio
   return relevantPosts.concat(relevantUpvotes);
 };
 
-export const useNotifications = ({ enabled }: { enabled: boolean }) => {
+export const useNotifications = () => {
   const { address } = useAccount();
   const [notifications, setNotifications] = useState<Notification[]>([]);
   const [unread, setUnread] = useState<Notification[]>([]);
@@ -170,11 +170,11 @@ export const useNotifications = ({ enabled }: { enabled: boolean }) => {
   useEffect(() => {
     // Getting nymOptions to avoid an error where sometime nymOptions are out of sync with the address
     const nymOptions = getNymOptions(address);
-    if (!address || !nymOptions || !enabled) {
+    if (!address || !nymOptions) {
       return;
     }
     fetchNotifications(address, nymOptions);
-  }, [address, enabled]);
+  }, [address]);
 
   return {
     notifications,

--- a/packages/frontend/src/hooks/useStupidHook.ts
+++ b/packages/frontend/src/hooks/useStupidHook.ts
@@ -1,0 +1,8 @@
+import { useState } from 'react';
+
+const useStupidHook = () => {
+  const [stupidState, setStupidState] = useState(0);
+  return { stupidState, setStupidState };
+};
+
+export default useStupidHook;

--- a/packages/frontend/src/hooks/useStupidHook.ts
+++ b/packages/frontend/src/hooks/useStupidHook.ts
@@ -1,8 +1,0 @@
-import { useState } from 'react';
-
-const useStupidHook = () => {
-  const [stupidState, setStupidState] = useState(0);
-  return { stupidState, setStupidState };
-};
-
-export default useStupidHook;

--- a/packages/frontend/src/pages/_app.tsx
+++ b/packages/frontend/src/pages/_app.tsx
@@ -43,7 +43,8 @@ export default function App({ Component, pageProps }: AppProps) {
   const { routeLoading, pushRoute } = usePushRoute();
 
   useEffect(() => {
-    const handleResize = () => setIsMobile(window.innerWidth <= 768);
+    // const handleResize = () => setIsMobile(window.innerWidth <= 768);
+    const handleResize = () => setIsMobile(false);
     handleResize();
     window.addEventListener('resize', handleResize);
     return () => {

--- a/packages/frontend/src/pages/_app.tsx
+++ b/packages/frontend/src/pages/_app.tsx
@@ -43,8 +43,7 @@ export default function App({ Component, pageProps }: AppProps) {
   const { routeLoading, pushRoute } = usePushRoute();
 
   useEffect(() => {
-    // const handleResize = () => setIsMobile(window.innerWidth <= 768);
-    const handleResize = () => setIsMobile(false);
+    const handleResize = () => setIsMobile(window.innerWidth <= 768);
     handleResize();
     window.addEventListener('resize', handleResize);
     return () => {

--- a/packages/frontend/src/pages/_app.tsx
+++ b/packages/frontend/src/pages/_app.tsx
@@ -9,7 +9,6 @@ import { HOME_DESCRIPTION, Seo, TITLE } from '@/components/global/Seo';
 import Head from 'next/head';
 import { ValidUserWarning } from '@/components/global/ValidUserWarning';
 import { getDefaultWallets } from '@rainbow-me/rainbowkit';
-import { polygon, optimism } from 'viem/chains';
 import { createContext, useEffect, useState } from 'react';
 import useUserInfo from '@/hooks/useUserInfo';
 import { UserContextType } from '@/types/components';
@@ -19,7 +18,7 @@ import { Header } from '@/components/Header';
 
 config.autoAddCss = false;
 
-const { chains, publicClient } = configureChains([mainnet, polygon, optimism], [publicProvider()]);
+const { chains, publicClient } = configureChains([mainnet], [publicProvider()]);
 
 const { connectors } = getDefaultWallets({
   appName: 'My RainbowKit App',

--- a/packages/frontend/src/pages/api/v1/notifications.ts
+++ b/packages/frontend/src/pages/api/v1/notifications.ts
@@ -1,16 +1,16 @@
 import prisma from '@/lib/prisma';
 import type { NextApiRequest, NextApiResponse } from 'next';
-import { postPreviewSelect, IPostPreview } from '@/types/api';
+import { postPreviewSelect, userUpvotesSelect } from '@/types/api';
+import { RawNotifications } from '@/types/api';
 
 const handleGetNotificationFeed = async (
   req: NextApiRequest,
-  res: NextApiResponse<IPostPreview[]>,
+  res: NextApiResponse<RawNotifications>,
 ) => {
   const startTime = req.query.startTime ? (req.query.startTime as string) : new Date(0);
   const endTime = req.query.endTime ? (req.query.endTime as string) : new Date();
 
-  console.log({ startTime, endTime });
-  const feed = await prisma.post.findMany({
+  const posts = await prisma.post.findMany({
     select: postPreviewSelect,
     where: {
       timestamp: {
@@ -23,7 +23,22 @@ const handleGetNotificationFeed = async (
     },
   });
 
-  res.send(feed);
+  const upvotes = await prisma.doxedUpvote.findMany({
+    select: userUpvotesSelect,
+    where: {
+      timestamp: {
+        gt: startTime,
+        lte: endTime,
+      },
+    },
+    orderBy: {
+      timestamp: 'desc',
+    },
+  });
+
+  const result = { posts, upvotes };
+
+  res.send(result);
 };
 
 // Entry point for the API below /api/v1/posts

--- a/packages/frontend/src/pages/notifications.tsx
+++ b/packages/frontend/src/pages/notifications.tsx
@@ -15,10 +15,7 @@ export default function Notifications() {
   const { address } = useAccount();
   const { pushRoute, nymOptions } = useContext(UserContext) as UserContextType;
   const { errorMsg, setError } = useError();
-  const { notifications, unread, setNotifications, setNotificationsAsRead, isLoading } =
-    useNotifications({
-      enabled: true,
-    });
+  const { notifications, unread, isLoading, setNotificationsAsRead } = useNotifications();
 
   const [filter, setFilter] = useState('all');
 

--- a/packages/frontend/src/pages/notifications.tsx
+++ b/packages/frontend/src/pages/notifications.tsx
@@ -75,7 +75,7 @@ export default function Notifications() {
                           setNotifications,
                           n.id,
                         );
-                        pushRoute(`/posts/${n.id}`);
+                        pushRoute(`/posts/${n.postId}`);
                       }}
                     >
                       <SingleNotification n={n} />

--- a/packages/frontend/src/pages/notifications.tsx
+++ b/packages/frontend/src/pages/notifications.tsx
@@ -5,7 +5,6 @@ import { UserContextType } from '@/types/components';
 import { useContext, useMemo, useState } from 'react';
 import { UserContext } from './_app';
 import { SingleNotification } from '@/components/notifications/SingleNotification';
-import { MarkAllAsRead, setNotificationAsRead } from '@/components/notifications/Notifications';
 import { useAccount } from 'wagmi';
 import { Filters } from '@/components/post/Filters';
 import { faCheck } from '@fortawesome/free-solid-svg-icons';
@@ -16,17 +15,18 @@ export default function Notifications() {
   const { address } = useAccount();
   const { pushRoute, nymOptions } = useContext(UserContext) as UserContextType;
   const { errorMsg, setError } = useError();
-  const { notifications, unreadNotifications, setNotifications, isLoading } = useNotifications({
-    enabled: true,
-  });
+  const { notifications, unread, setNotifications, setNotificationsAsRead, isLoading } =
+    useNotifications({
+      enabled: true,
+    });
 
   const [filter, setFilter] = useState('all');
 
   console.log({ notifications }, 'from page component');
 
   const notificationsToShow = useMemo(
-    () => (filter === 'unread' ? unreadNotifications : notifications),
-    [filter, notifications, unreadNotifications],
+    () => (filter === 'unread' ? unread : notifications),
+    [filter, notifications, unread],
   );
 
   const filters = {
@@ -55,9 +55,7 @@ export default function Notifications() {
                   />
                   <div
                     className="flex gap-1 justify-end items-center"
-                    onClick={() =>
-                      MarkAllAsRead(address as string, notifications, setNotifications)
-                    }
+                    onClick={() => setNotificationsAsRead(address, '', true)}
                   >
                     <FontAwesomeIcon icon={faCheck} size={'xs'} />
                     <p className="secondary hover:underline">Mark all as read</p>
@@ -69,12 +67,7 @@ export default function Notifications() {
                       className="flex gap-4 justify-between outline-none rounded-2xl transition-all shadow-sm bg-white p-3 md:px-5 md:py-4 border border-gray-200 hover:border-gray-300 hover:cursor-pointer w-full"
                       key={i}
                       onClick={() => {
-                        setNotificationAsRead(
-                          address as string,
-                          notifications,
-                          setNotifications,
-                          n.id,
-                        );
+                        setNotificationsAsRead(address, n.id);
                         pushRoute(`/posts/${n.postId}`);
                       }}
                     >

--- a/packages/frontend/types/api/index.ts
+++ b/packages/frontend/types/api/index.ts
@@ -2,3 +2,4 @@ export * from './postSelect';
 export * from './postPreviewSelect';
 export * from './userUpvotesSelect';
 export * from './users';
+export * from './notifications';

--- a/packages/frontend/types/api/notifications.ts
+++ b/packages/frontend/types/api/notifications.ts
@@ -1,34 +1,6 @@
-// Notifications for frontend
 import { IPostPreview } from './postPreviewSelect';
 import { IUserUpvote } from './userUpvotesSelect';
 
 // Either Upvote or Post
 
-export enum NotificationType {
-  Upvote,
-  DirectReply,
-  DiscussionReply,
-}
-
 export type RawNotifications = { upvotes: IUserUpvote[]; posts: IPostPreview[] };
-
-export interface BaseNotification {
-  read: boolean;
-  type: NotificationType;
-  id: string; // Either postId or upvoteId
-  postId: string; // Always postId
-  userId: string;
-  title: string; // notification Title.
-  body: string; // notification Body.
-  timestamp: Date;
-}
-
-export type UpvoteNotification = BaseNotification & {
-  type: NotificationType.Upvote;
-};
-
-export type ReplyNotification = BaseNotification & {
-  type: NotificationType.DirectReply | NotificationType.DiscussionReply;
-};
-
-export type Notification = UpvoteNotification | ReplyNotification;

--- a/packages/frontend/types/api/notifications.ts
+++ b/packages/frontend/types/api/notifications.ts
@@ -1,0 +1,34 @@
+// Notifications for frontend
+import { IPostPreview } from './postPreviewSelect';
+import { IUserUpvote } from './userUpvotesSelect';
+
+// Either Upvote or Post
+
+export enum NotificationType {
+  Upvote,
+  DirectReply,
+  DiscussionReply,
+}
+
+export type RawNotifications = { upvotes: IUserUpvote[]; posts: IPostPreview[] };
+
+export interface BaseNotification {
+  read: boolean;
+  type: NotificationType;
+  id: string; // Either postId or upvoteId
+  postId: string; // Always postId
+  userId: string;
+  title: string; // notification Title.
+  body: string; // notification Body.
+  timestamp: Date;
+}
+
+export type UpvoteNotification = BaseNotification & {
+  type: NotificationType.Upvote;
+};
+
+export type ReplyNotification = BaseNotification & {
+  type: NotificationType.DirectReply | NotificationType.DiscussionReply;
+};
+
+export type Notification = UpvoteNotification | ReplyNotification;

--- a/packages/frontend/types/api/userUpvotesSelect.ts
+++ b/packages/frontend/types/api/userUpvotesSelect.ts
@@ -5,6 +5,7 @@ import { postPreviewSelect } from './postPreviewSelect';
 
 export const userUpvotesSelect = {
   id: true,
+  address: true,
   timestamp: true,
   post: {
     select: { ...postPreviewSelect },

--- a/packages/frontend/types/components/index.ts
+++ b/packages/frontend/types/components/index.ts
@@ -59,33 +59,6 @@ export type UserContextType = {
   pushRoute: (route: string) => void;
 };
 
-export enum NotificationType {
-  Upvote,
-  DirectReply,
-  DiscussionReply,
-}
-
-export interface BaseNotification {
-  entityId: string;
-  read: boolean;
-  type: NotificationType;
-  id: string;
-  userId: string;
-  title: string;
-  body: string;
-  timestamp: Date;
-}
-
-export type UpvoteNotification = BaseNotification & {
-  type: NotificationType.Upvote;
-};
-
-export type ReplyNotification = BaseNotification & {
-  type: NotificationType.DirectReply | NotificationType.DiscussionReply;
-};
-
-export type Notification = ReplyNotification | UpvoteNotification;
-
 export type NotificationsContextType = {
   notifications: Notification[];
   unreadNotifications: Notification[];

--- a/packages/frontend/types/notifications/index.ts
+++ b/packages/frontend/types/notifications/index.ts
@@ -1,0 +1,30 @@
+export enum NotificationType {
+  Upvote,
+  DirectReply,
+  DiscussionReply,
+}
+
+export interface NotificationMap {
+  [id: string]: Notification;
+}
+
+export interface BaseNotification {
+  read: boolean;
+  type: NotificationType;
+  id: string; // Either postId or upvoteId
+  postId: string; // Always postId
+  userId: string;
+  title: string; // notification Title.
+  body: string; // notification Body.
+  timestamp: Date;
+}
+
+export type UpvoteNotification = BaseNotification & {
+  type: NotificationType.Upvote;
+};
+
+export type ReplyNotification = BaseNotification & {
+  type: NotificationType.DirectReply | NotificationType.DiscussionReply;
+};
+
+export type Notification = UpvoteNotification | ReplyNotification;


### PR DESCRIPTION
- Fixes hydration error (was caused by Wagmi hook again lol)
- Cleans up logic to mark all as read

Known problems:
- If wallet is not connected, user's profile doesn't exist.
    - Means we have no easy way to show the `Users` page to site visitors. 
- Marking a notification as read doesn't propagate between `notifications` and `Notifications.tsx`. Also, because I learned that hooks are like copies of state, not shared state, `refetchNotifications` won't actually re-render our new values so that needs to be in a Context as well. 