### PR TITLE
Notifications UI updates

### DIFF
--- a/packages/frontend/src/components/Header.tsx
+++ b/packages/frontend/src/components/Header.tsx
@@ -7,17 +7,13 @@ import { UserContext } from '@/pages/_app';
 import { UserContextType } from '@/types/components';
 import { useAccount } from 'wagmi';
 import { Notifications } from './notifications/Notifications';
+import { useIsMounted } from '@/hooks/useIsMounted';
 
 export const Header = () => {
   const { address } = useAccount();
   const { isMobile, isValid, pushRoute } = useContext(UserContext) as UserContextType;
 
-  const [localAddress, setLocalAddress] = useState('');
-
-  useEffect(() => {
-    // Prevents server side mismatch with address. Idk why
-    if (address) setLocalAddress(address);
-  }, [address]);
+  const isMounted = useIsMounted();
 
   return (
     <>
@@ -42,9 +38,9 @@ export const Header = () => {
               </p>
             </div>
             <div className="flex gap-4 items-center">
-              {localAddress && isValid && <Notifications />}
-              {(!isMobile || !localAddress || !isValid) && <ConnectWallet />}
-              <MyProfile address={localAddress} />
+              {isMounted && address && isValid && <Notifications />}
+              {(!isMobile || !address || !isValid) && <ConnectWallet />}
+              {isMounted && address && <MyProfile address={address} />}
             </div>
           </nav>
           {!isMobile && (

--- a/packages/frontend/src/components/global/Spinner.tsx
+++ b/packages/frontend/src/components/global/Spinner.tsx
@@ -1,33 +1,17 @@
-const Spinner = () => {
+interface SpinnerProps {
+  color?: string;
+  size?: string;
+}
+
+const Spinner = (props: SpinnerProps) => {
+  const { color, size } = props;
   return (
     <div className="flex justify-center items-center">
       <div
-        className="
-        border-2 border-t-2 border-gray-800
-        loader
-        ease-linear
-        rounded-full
-        h-4
-        w-4
-      "
+        className={`border-2 border-t-2 border-t-white loader ease-linear rounded-full ${
+          size ? 'w-' + size + ' h-' + size : 'w-4 h-4'
+        } ${color ? 'border-' + color : 'border-gray-500'}`}
       />
-      <style jsx>
-        {`
-          .loader {
-            border-top-color: white;
-            animation: spinner 0.6s linear infinite;
-          }
-
-          @keyframes spinner {
-            0% {
-              transform: rotate(0deg);
-            }
-            100% {
-              transform: rotate(360deg);
-            }
-          }
-        `}
-      </style>
     </div>
   );
 };

--- a/packages/frontend/src/components/notifications/Notifications.tsx
+++ b/packages/frontend/src/components/notifications/Notifications.tsx
@@ -84,13 +84,17 @@ export const Notifications = () => {
                             pushRoute(`/posts/${n.postId}`);
                           }}
                         >
-                          <SingleNotification n={n} setAsRead={setNotificationsAsRead} />
+                          <SingleNotification
+                            n={n}
+                            setAsRead={setNotificationsAsRead}
+                            trim={true}
+                          />
                         </Menu.Item>
                       );
                     })}
                     <Menu.Item
                       as={'div'}
-                      className="py-2 hover:underline"
+                      className="py-2 hover:underline hover:bg-gray-200 rounded-b-xl"
                       onClick={() => pushRoute('/notifications')}
                     >
                       <p className="text-center">See All Notifications</p>

--- a/packages/frontend/src/components/notifications/Notifications.tsx
+++ b/packages/frontend/src/components/notifications/Notifications.tsx
@@ -10,13 +10,13 @@ import { SingleNotification } from './SingleNotification';
 import { RefreshNotifications } from './RefreshNotifications';
 import { UserContextType } from '@/types/components';
 import { NotificationsContextType } from '@/types/notifications';
+import { RetryError } from '../global/RetryError';
 
 export const Notifications = () => {
   const { address } = useAccount();
   const { isMobile, nymOptions, pushRoute } = useContext(UserContext) as UserContextType;
-  const { notifications, unread, isLoading, setNotificationsAsRead, lastRefresh } = useContext(
-    NotificationsContext,
-  ) as NotificationsContextType;
+  const { notifications, unread, isLoading, setNotificationsAsRead, fetchNotifications, errorMsg } =
+    useContext(NotificationsContext) as NotificationsContextType;
   const [filter, setFilter] = useState('all');
 
   const notificationsToShow = useMemo(
@@ -104,6 +104,13 @@ export const Notifications = () => {
                   <div className="p-4">
                     <Spinner />
                   </div>
+                ) : errorMsg ? (
+                  <RetryError
+                    message={'Could not fetch notifications: '}
+                    refetchHandler={() =>
+                      fetchNotifications({ address: address as string, nymOptions })
+                    }
+                  />
                 ) : (
                   <p className="p-4 text-center">No notifications</p>
                 )}

--- a/packages/frontend/src/components/notifications/Notifications.tsx
+++ b/packages/frontend/src/components/notifications/Notifications.tsx
@@ -14,7 +14,7 @@ import { NotificationsContextType } from '@/types/notifications';
 export const Notifications = () => {
   const { address } = useAccount();
   const { isMobile, nymOptions, pushRoute } = useContext(UserContext) as UserContextType;
-  const { notifications, unread, isLoading, setNotificationsAsRead } = useContext(
+  const { notifications, unread, isLoading, setNotificationsAsRead, lastRefresh } = useContext(
     NotificationsContext,
   ) as NotificationsContextType;
   const [filter, setFilter] = useState('all');

--- a/packages/frontend/src/components/notifications/Notifications.tsx
+++ b/packages/frontend/src/components/notifications/Notifications.tsx
@@ -64,7 +64,7 @@ export const Notifications = () => {
                     />
                     <div
                       className="flex gap-1 justify-end items-center"
-                      onClick={() => setNotificationsAsRead(address as string, '', true)}
+                      onClick={() => setNotificationsAsRead({ address, markAll: true })}
                     >
                       <FontAwesomeIcon icon={faCheck} size={'xs'} />
                       <p className="secondary hover:underline">Mark all as read</p>
@@ -82,7 +82,7 @@ export const Notifications = () => {
                             n.read ? 'bg-white' : 'bg-gray-100'
                           }`}
                           onClick={() => {
-                            setNotificationsAsRead(address as string, n.id);
+                            setNotificationsAsRead({ address, id: n.id });
                             pushRoute(`/posts/${n.postId}`);
                           }}
                         >

--- a/packages/frontend/src/components/notifications/Notifications.tsx
+++ b/packages/frontend/src/components/notifications/Notifications.tsx
@@ -107,6 +107,7 @@ export const Notifications = () => {
                 ) : errorMsg ? (
                   <RetryError
                     message={'Could not fetch notifications: '}
+                    error={errorMsg}
                     refetchHandler={() =>
                       fetchNotifications({ address: address as string, nymOptions })
                     }

--- a/packages/frontend/src/components/notifications/Notifications.tsx
+++ b/packages/frontend/src/components/notifications/Notifications.tsx
@@ -1,4 +1,4 @@
-import { faBell, faCheck, faRefresh, faXmark } from '@fortawesome/free-solid-svg-icons';
+import { faBell, faCheck, faXmark } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { Menu } from '@headlessui/react';
 import Spinner from '../global/Spinner';
@@ -51,7 +51,7 @@ export const Notifications = () => {
                 <div className="flex flex-col gap-2 px-3 mb-2">
                   <div className="flex items-center justify-between mt-2">
                     <h4>Notifications</h4>
-                    <div className="flex gap-3">
+                    <div className="flex gap-3 items-center">
                       <RefreshNotifications nymOptions={nymOptions} />
                       <FontAwesomeIcon icon={faXmark} size={'lg'} color="#98A2B3" onClick={close} />
                     </div>
@@ -78,9 +78,7 @@ export const Notifications = () => {
                         <Menu.Item
                           as={'div'}
                           key={i}
-                          className={`w-full flex items-center gap-2 px-3 py-2 ${
-                            n.read ? 'bg-white' : 'bg-gray-100'
-                          }`}
+                          className="w-full flex items-center gap-2 px-3 py-2 rounded-xl bg-white border border-white hover:border-gray-500"
                           onClick={() => {
                             setNotificationsAsRead({ address, id: n.id });
                             pushRoute(`/posts/${n.postId}`);

--- a/packages/frontend/src/components/notifications/Notifications.tsx
+++ b/packages/frontend/src/components/notifications/Notifications.tsx
@@ -78,7 +78,7 @@ export const Notifications = () => {
                         <Menu.Item
                           as={'div'}
                           key={i}
-                          className={`w-full flex items-center gap-2 px-3 py-2 hover:bg-gray-200 ${
+                          className={`w-full flex items-center gap-2 px-3 py-2 ${
                             n.read ? 'bg-white' : 'bg-gray-100'
                           }`}
                           onClick={() => {
@@ -86,7 +86,7 @@ export const Notifications = () => {
                             pushRoute(`/posts/${n.postId}`);
                           }}
                         >
-                          <SingleNotification n={n} />
+                          <SingleNotification n={n} setAsRead={setNotificationsAsRead} />
                         </Menu.Item>
                       );
                     })}

--- a/packages/frontend/src/components/notifications/RefreshNotifications.tsx
+++ b/packages/frontend/src/components/notifications/RefreshNotifications.tsx
@@ -1,38 +1,30 @@
-import { useNotifications } from '@/hooks/useNotifications';
-import { useEffect, useState } from 'react';
+import { useContext, useState } from 'react';
 import { useAccount } from 'wagmi';
 import Spinner from '../global/Spinner';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faRefresh } from '@fortawesome/free-solid-svg-icons';
 import { ClientName } from '@/types/components';
-import { fromNowDate } from '@/lib/example-utils';
+import { NotificationsContext } from '@/pages/_app';
+import { NotificationsContextType } from '@/types/notifications';
 
 export const RefreshNotifications = (props: { nymOptions: ClientName[] }) => {
   const { nymOptions } = props;
   const { address } = useAccount();
-  const { fetchNotifications } = useNotifications();
+  const { fetchNotifications, lastRefresh } = useContext(
+    NotificationsContext,
+  ) as NotificationsContextType;
   const [refetching, setRefetching] = useState(false);
-  const [refreshTime, setRefreshTime] = useState(new Date());
-  const [lastRefresh, setLastRefresh] = useState(fromNowDate(new Date()));
-
-  useEffect(() => {
-    setInterval(() => {
-      const fromNow = fromNowDate(refreshTime);
-      setLastRefresh(fromNow);
-    }, 5000);
-  });
 
   const refetch = async () => {
     if (address) {
       setRefetching(true);
-      await fetchNotifications(address, nymOptions);
-      setRefreshTime(new Date());
+      await fetchNotifications({ address, nymOptions });
       setRefetching(false);
     }
   };
   return (
     <div className="flex gap-4 items-center">
-      <p className="secondary">Last Refresh: {lastRefresh}</p>
+      {lastRefresh && <p className="secondary">Last Refresh: {lastRefresh}</p>}
       <div className="cursor-pointer">
         <div className="flex items-center w-5 h-4">
           {refetching ? (

--- a/packages/frontend/src/components/notifications/RefreshNotifications.tsx
+++ b/packages/frontend/src/components/notifications/RefreshNotifications.tsx
@@ -22,8 +22,6 @@ export const RefreshNotifications = (props: { nymOptions: ClientName[] }) => {
     }, 5000);
   });
 
-  console.log({ lastRefresh });
-
   const refetch = async () => {
     if (address) {
       setRefetching(true);

--- a/packages/frontend/src/components/notifications/RefreshNotifications.tsx
+++ b/packages/frontend/src/components/notifications/RefreshNotifications.tsx
@@ -1,5 +1,5 @@
 import { useNotifications } from '@/hooks/useNotifications';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useAccount } from 'wagmi';
 import Spinner from '../global/Spinner';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
@@ -12,13 +12,23 @@ export const RefreshNotifications = (props: { nymOptions: ClientName[] }) => {
   const { address } = useAccount();
   const { fetchNotifications } = useNotifications();
   const [refetching, setRefetching] = useState(false);
+  const [refreshTime, setRefreshTime] = useState(new Date());
   const [lastRefresh, setLastRefresh] = useState(fromNowDate(new Date()));
+
+  useEffect(() => {
+    setInterval(() => {
+      const fromNow = fromNowDate(refreshTime);
+      setLastRefresh(fromNow);
+    }, 5000);
+  });
+
+  console.log({ lastRefresh });
 
   const refetch = async () => {
     if (address) {
       setRefetching(true);
       await fetchNotifications(address, nymOptions);
-      setLastRefresh(fromNowDate(new Date()));
+      setRefreshTime(new Date());
       setRefetching(false);
     }
   };

--- a/packages/frontend/src/components/notifications/RefreshNotifications.tsx
+++ b/packages/frontend/src/components/notifications/RefreshNotifications.tsx
@@ -24,7 +24,7 @@ export const RefreshNotifications = (props: { nymOptions: ClientName[] }) => {
   };
   return (
     <div className="flex gap-4 items-center">
-      {lastRefresh && <p className="secondary">Last Refresh: {lastRefresh}</p>}
+      {lastRefresh && <p className="secondary">Last updated: {lastRefresh}</p>}
       <div className="cursor-pointer">
         <div className="flex items-center w-5 h-4">
           {refetching ? (

--- a/packages/frontend/src/components/notifications/RefreshNotifications.tsx
+++ b/packages/frontend/src/components/notifications/RefreshNotifications.tsx
@@ -5,27 +5,35 @@ import Spinner from '../global/Spinner';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faRefresh } from '@fortawesome/free-solid-svg-icons';
 import { ClientName } from '@/types/components';
+import { fromNowDate } from '@/lib/example-utils';
 
 export const RefreshNotifications = (props: { nymOptions: ClientName[] }) => {
   const { nymOptions } = props;
   const { address } = useAccount();
   const { fetchNotifications } = useNotifications();
   const [refetching, setRefetching] = useState(false);
+  const [lastRefresh, setLastRefresh] = useState(fromNowDate(new Date()));
 
   const refetch = async () => {
     if (address) {
       setRefetching(true);
       await fetchNotifications(address, nymOptions);
+      setLastRefresh(fromNowDate(new Date()));
       setRefetching(false);
     }
   };
   return (
-    <div className="cursor-pointer">
-      {refetching ? (
-        <Spinner />
-      ) : (
-        <FontAwesomeIcon icon={faRefresh} size={'lg'} color={'#98A2B3'} onClick={refetch} />
-      )}
+    <div className="flex gap-4 items-center">
+      <p className="secondary">Last Refresh: {lastRefresh}</p>
+      <div className="cursor-pointer">
+        <div className="flex items-center w-5 h-4">
+          {refetching ? (
+            <Spinner />
+          ) : (
+            <FontAwesomeIcon icon={faRefresh} size={'lg'} color={'#98A2B3'} onClick={refetch} />
+          )}
+        </div>
+      </div>
     </div>
   );
 };

--- a/packages/frontend/src/components/notifications/SingleNotification.tsx
+++ b/packages/frontend/src/components/notifications/SingleNotification.tsx
@@ -1,9 +1,18 @@
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { UserAvatar } from '../global/UserAvatar';
-import { faCircleUp, faEllipsis, faReply, faReplyAll } from '@fortawesome/free-solid-svg-icons';
+import {
+  faCheck,
+  faCircleUp,
+  faEllipsis,
+  faReply,
+  faReplyAll,
+} from '@fortawesome/free-solid-svg-icons';
 import { UserName } from '../global/UserName';
 import { fromNowDate } from '@/lib/example-utils';
 import { NotificationType, Notification } from '@/types/notifications';
+import { useContext, useState } from 'react';
+import { NotificationsContext } from '@/pages/_app';
+import { useAccount } from 'wagmi';
 
 const getNotificationFromType = (type: NotificationType) => {
   switch (type) {
@@ -16,8 +25,14 @@ const getNotificationFromType = (type: NotificationType) => {
   }
 };
 
-export const SingleNotification = (props: { n: Notification }) => {
-  const { n } = props;
+export const SingleNotification = (props: {
+  n: Notification;
+  setAsRead: (address: string, id: string, markAll?: boolean) => void;
+}) => {
+  const { address } = useAccount();
+  const { n, setAsRead } = props;
+  const [showOptions, setShowOptions] = useState(false);
+
   return (
     <>
       <div className="shrink-0 h-min relative">
@@ -47,8 +62,23 @@ export const SingleNotification = (props: { n: Notification }) => {
           <span>{n.body}</span>
         </p>
       </div>
-      <div className="px-1 hover:bg-gray-200 rounded-md">
+      <div
+        className="relative px-1 hover:bg-gray-200 rounded-md"
+        onClick={(e) => {
+          e.stopPropagation();
+          setShowOptions(!showOptions);
+        }}
+      >
         <FontAwesomeIcon icon={faEllipsis} />
+        {showOptions && (
+          <div
+            className="absolute top-full right-1/2 mt-2 shadow-sm border border-gray-200 bg-white hover:bg-gray-100 rounded-xl p-2 w-max flex gap-2 items-center"
+            onClick={() => setAsRead(address as string, n.id)}
+          >
+            <FontAwesomeIcon icon={faCheck} size={'sm'} />
+            <p>Mark as read</p>
+          </div>
+        )}
       </div>
     </>
   );

--- a/packages/frontend/src/components/notifications/SingleNotification.tsx
+++ b/packages/frontend/src/components/notifications/SingleNotification.tsx
@@ -9,7 +9,7 @@ import {
 } from '@fortawesome/free-solid-svg-icons';
 import { UserName } from '../global/UserName';
 import { fromNowDate } from '@/lib/example-utils';
-import { NotificationType, Notification } from '@/types/notifications';
+import { NotificationType, Notification, setReadArgs } from '@/types/notifications';
 import { useContext, useState } from 'react';
 import { NotificationsContext } from '@/pages/_app';
 import { useAccount } from 'wagmi';
@@ -27,7 +27,7 @@ const getNotificationFromType = (type: NotificationType) => {
 
 export const SingleNotification = (props: {
   n: Notification;
-  setAsRead: (address: string, id: string, markAll?: boolean) => void;
+  setAsRead: (args: setReadArgs) => void;
 }) => {
   const { address } = useAccount();
   const { n, setAsRead } = props;
@@ -73,7 +73,7 @@ export const SingleNotification = (props: {
         {showOptions && (
           <div
             className="absolute top-full right-1/2 mt-2 shadow-sm border border-gray-200 bg-white hover:bg-gray-100 rounded-xl p-2 w-max flex gap-2 items-center"
-            onClick={() => setAsRead(address as string, n.id)}
+            onClick={() => setAsRead({ address, id: n.id })}
           >
             <FontAwesomeIcon icon={faCheck} size={'sm'} />
             <p>Mark as read</p>

--- a/packages/frontend/src/components/notifications/SingleNotification.tsx
+++ b/packages/frontend/src/components/notifications/SingleNotification.tsx
@@ -10,8 +10,7 @@ import {
 import { UserName } from '../global/UserName';
 import { fromNowDate } from '@/lib/example-utils';
 import { NotificationType, Notification, setReadArgs } from '@/types/notifications';
-import { useContext, useState } from 'react';
-import { NotificationsContext } from '@/pages/_app';
+import { useState } from 'react';
 import { useAccount } from 'wagmi';
 
 const getNotificationFromType = (type: NotificationType) => {
@@ -36,13 +35,16 @@ export const SingleNotification = (props: {
   return (
     <>
       <div className="shrink-0 h-min relative">
-        <UserAvatar userId={n.userId} width={35} />
-        <div className="absolute bottom-0 left-full -translate-x-full flex items-center justify-center bg-[#0E76FD] rounded-full p-1 w-[15px] h-[15px]">
-          <FontAwesomeIcon
-            icon={getNotificationFromType(n.type).icon}
-            size={'2xs'}
-            color={'#ffffff'}
-          />
+        <div className="flex gap-2 items-center">
+          <div className={`w-2.5 h-2.5 ${n.read ? 'bg-white' : 'bg-[#0E76FD]'} rounded-full`} />
+          <UserAvatar userId={n.userId} width={35} />
+          <div className="absolute bottom-0 left-full -translate-x-full flex items-center justify-center bg-[#0E76FD] rounded-full p-1 w-[15px] h-[15px]">
+            <FontAwesomeIcon
+              icon={getNotificationFromType(n.type).icon}
+              size={'2xs'}
+              color={'#ffffff'}
+            />
+          </div>
         </div>
       </div>
       <div className="min-w-0 shrink grow flex flex-col gap-2">

--- a/packages/frontend/src/components/notifications/SingleNotification.tsx
+++ b/packages/frontend/src/components/notifications/SingleNotification.tsx
@@ -8,7 +8,7 @@ import {
   faReplyAll,
 } from '@fortawesome/free-solid-svg-icons';
 import { UserName } from '../global/UserName';
-import { fromNowDate } from '@/lib/example-utils';
+import { fromNowDate, trimText } from '@/lib/example-utils';
 import { NotificationType, Notification, setReadArgs } from '@/types/notifications';
 import { useState } from 'react';
 import { useAccount } from 'wagmi';
@@ -27,9 +27,10 @@ const getNotificationFromType = (type: NotificationType) => {
 export const SingleNotification = (props: {
   n: Notification;
   setAsRead: (args: setReadArgs) => void;
+  trim?: boolean;
 }) => {
   const { address } = useAccount();
-  const { n, setAsRead } = props;
+  const { n, setAsRead, trim } = props;
   const [showOptions, setShowOptions] = useState(false);
 
   return (
@@ -61,7 +62,7 @@ export const SingleNotification = (props: {
         </div>
         <p>
           <span>{getNotificationFromType(n.type).text}</span>
-          <span>{n.body}</span>
+          <span>{trim ? trimText(n.body) : n.body}</span>
         </p>
       </div>
       <div

--- a/packages/frontend/src/components/notifications/SingleNotification.tsx
+++ b/packages/frontend/src/components/notifications/SingleNotification.tsx
@@ -1,6 +1,6 @@
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { UserAvatar } from '../global/UserAvatar';
-import { faCircleUp, faReply, faReplyAll } from '@fortawesome/free-solid-svg-icons';
+import { faCircleUp, faEllipsis, faReply, faReplyAll } from '@fortawesome/free-solid-svg-icons';
 import { UserName } from '../global/UserName';
 import { fromNowDate } from '@/lib/example-utils';
 import { NotificationType, Notification } from '@/types/notifications';
@@ -31,7 +31,7 @@ export const SingleNotification = (props: { n: Notification }) => {
         </div>
       </div>
       <div className="min-w-0 shrink grow flex flex-col gap-2">
-        <div className="w-full flex gap-1 items-center">
+        <div className="w-full flex gap-2 items-center">
           <p className="breakText">
             <span className="postDetail">
               <UserName userId={n.userId} trim={true} />
@@ -39,12 +39,16 @@ export const SingleNotification = (props: { n: Notification }) => {
             <span className="secondary"> on </span>
             <span className="postDetail">{n.title}</span>
           </p>
+          <p className="secondary">-</p>
           <p className="shrink-0 secondary">{fromNowDate(n.timestamp)}</p>
         </div>
         <p>
           <span>{getNotificationFromType(n.type).text}</span>
           <span>{n.body}</span>
         </p>
+      </div>
+      <div className="px-1 hover:bg-gray-200 rounded-md">
+        <FontAwesomeIcon icon={faEllipsis} />
       </div>
     </>
   );

--- a/packages/frontend/src/hooks/useIsMounted.ts
+++ b/packages/frontend/src/hooks/useIsMounted.ts
@@ -1,0 +1,9 @@
+import { useEffect, useState } from 'react';
+
+export const useIsMounted = () => {
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => setMounted(true), []);
+
+  return mounted;
+};

--- a/packages/frontend/src/hooks/useNotifications.ts
+++ b/packages/frontend/src/hooks/useNotifications.ts
@@ -2,7 +2,12 @@ import axios from 'axios';
 import { useEffect, useMemo, useState } from 'react';
 import { IPostPreview, IUserUpvote, RawNotifications } from '@/types/api';
 import { ClientName } from '@/types/components';
-import { Notification, NotificationMap, NotificationType } from '@/types/notifications';
+import {
+  Notification,
+  NotificationMap,
+  NotificationType,
+  setReadArgs,
+} from '@/types/notifications';
 import { getNymOptions } from './useUserInfo';
 import { getUserIdFromName } from '@/lib/example-utils';
 import { useAccount } from 'wagmi';
@@ -110,7 +115,7 @@ export const useNotifications = () => {
   const [isLoading, setIsLoading] = useState(false);
   const unread = useMemo(() => notifications.filter((n) => !n.read), [notifications]);
 
-  const setNotificationsAsRead = (address: string | undefined, id: string, markAll = false) => {
+  const setNotificationsAsRead = ({ address, id, markAll }: setReadArgs) => {
     if (notifications && address) {
       // update notifications in memory
       const newNotifications = notifications.map((n) => {

--- a/packages/frontend/src/hooks/useNotifications.ts
+++ b/packages/frontend/src/hooks/useNotifications.ts
@@ -118,7 +118,6 @@ export const useNotifications = () => {
         return n;
       });
       setNotifications(newNotifications);
-      console.log({ unread }, 'inside hook');
       const map = notificationsListToMap(newNotifications);
       // write new map to local storage
       setNotificationsInLocalStorage(address, map);

--- a/packages/frontend/src/hooks/useNotifications.ts
+++ b/packages/frontend/src/hooks/useNotifications.ts
@@ -115,7 +115,7 @@ export const useNotifications = () => {
   const [notifications, setNotifications] = useState<Notification[]>([]);
   const [isLoading, setIsLoading] = useState(false);
   const unread = useMemo(() => notifications.filter((n) => !n.read), [notifications]);
-  const [refreshTime, setRefreshTime] = useState(new Date());
+  const [refreshTime, setRefreshTime] = useState<Date | null>(null);
   const [lastRefresh, setLastRefresh] = useState('');
   const { errorMsg, setError } = useError();
 
@@ -186,11 +186,16 @@ export const useNotifications = () => {
     fetchNotifications({ address, nymOptions });
   }, [address]);
 
+  const calculateLastRefresh = (refreshTime: Date) => {
+    const fromNow = fromNowDate(refreshTime);
+    setLastRefresh(fromNow);
+  };
+
   useEffect(() => {
-    setInterval(() => {
-      const fromNow = fromNowDate(refreshTime);
-      setLastRefresh(fromNow);
-    }, 5000);
+    if (refreshTime) {
+      calculateLastRefresh(refreshTime);
+      setInterval(() => calculateLastRefresh(refreshTime), 5000);
+    }
   }, [refreshTime]);
 
   return {

--- a/packages/frontend/src/pages/_app.tsx
+++ b/packages/frontend/src/pages/_app.tsx
@@ -49,6 +49,7 @@ export default function App({ Component, pageProps }: AppProps) {
     setNotificationsAsRead,
     fetchNotifications,
     lastRefresh,
+    errorMsg,
   } = useNotifications();
   const [isMobile, setIsMobile] = useState(false);
   const { routeLoading, pushRoute } = usePushRoute();
@@ -81,6 +82,7 @@ export default function App({ Component, pageProps }: AppProps) {
               setNotificationsAsRead,
               fetchNotifications,
               lastRefresh,
+              errorMsg,
             }}
           >
             <Header />

--- a/packages/frontend/src/pages/_app.tsx
+++ b/packages/frontend/src/pages/_app.tsx
@@ -42,7 +42,14 @@ export const NotificationsContext = createContext<NotificationsContextType | nul
 export default function App({ Component, pageProps }: AppProps) {
   const { address } = useAccount();
   const { nymOptions, setNymOptions, isValid } = useUserInfo({ address: address });
-  const { notifications, unread, isLoading, setNotificationsAsRead } = useNotifications();
+  const {
+    notifications,
+    unread,
+    isLoading,
+    setNotificationsAsRead,
+    fetchNotifications,
+    lastRefresh,
+  } = useNotifications();
   const [isMobile, setIsMobile] = useState(false);
   const { routeLoading, pushRoute } = usePushRoute();
 
@@ -67,7 +74,14 @@ export default function App({ Component, pageProps }: AppProps) {
           <Seo title={TITLE} description={HOME_DESCRIPTION} />
           {routeLoading && <RouteLoadingSpinner />}
           <NotificationsContext.Provider
-            value={{ notifications, unread, isLoading, setNotificationsAsRead }}
+            value={{
+              notifications,
+              unread,
+              isLoading,
+              setNotificationsAsRead,
+              fetchNotifications,
+              lastRefresh,
+            }}
           >
             <Header />
             <Component {...pageProps} />

--- a/packages/frontend/src/pages/notifications.tsx
+++ b/packages/frontend/src/pages/notifications.tsx
@@ -75,7 +75,7 @@ export default function Notifications() {
                         pushRoute(`/posts/${n.postId}`);
                       }}
                     >
-                      <SingleNotification n={n} />
+                      <SingleNotification n={n} setAsRead={setNotificationsAsRead} />
                     </div>
                   ))
                 ) : (

--- a/packages/frontend/src/pages/notifications.tsx
+++ b/packages/frontend/src/pages/notifications.tsx
@@ -53,6 +53,7 @@ export default function Notifications() {
             ) : errorMsg ? (
               <RetryError
                 message={'Could not fetch notifications: '}
+                error={errorMsg}
                 refetchHandler={() =>
                   fetchNotifications({ address: address as string, nymOptions })
                 }

--- a/packages/frontend/src/pages/notifications.tsx
+++ b/packages/frontend/src/pages/notifications.tsx
@@ -11,9 +11,11 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { RefreshNotifications } from '@/components/notifications/RefreshNotifications';
 import { WalletWarning } from '@/components/WalletWarning';
 import { NotificationsContextType } from '@/types/notifications';
+import { useIsMounted } from '@/hooks/useIsMounted';
 
 export default function Notifications() {
   const { address } = useAccount();
+  const isMounted = useIsMounted();
   const { isValid, pushRoute, nymOptions } = useContext(UserContext) as UserContextType;
   const { errorMsg, setError } = useError();
   const { notifications, unread, isLoading, setNotificationsAsRead } = useContext(
@@ -59,7 +61,7 @@ export default function Notifications() {
                   />
                   <div
                     className="flex gap-1 justify-end items-center"
-                    onClick={() => setNotificationsAsRead(address as string, '', true)}
+                    onClick={() => setNotificationsAsRead({ address, markAll: true })}
                   >
                     <FontAwesomeIcon icon={faCheck} size={'xs'} />
                     <p className="secondary hover:underline">Mark all as read</p>
@@ -71,7 +73,7 @@ export default function Notifications() {
                       className="flex gap-4 justify-between items-center outline-none rounded-2xl transition-all shadow-sm bg-white p-3 md:px-5 md:py-4 border border-gray-200 hover:border-gray-300 hover:cursor-pointer w-full"
                       key={i}
                       onClick={() => {
-                        setNotificationsAsRead(address as string, n.id);
+                        setNotificationsAsRead({ address, id: n.id });
                         pushRoute(`/posts/${n.postId}`);
                       }}
                     >
@@ -85,7 +87,7 @@ export default function Notifications() {
             ) : (
               <p className="p-4 text-center">No notifications</p>
             )}
-            {showWalletWarning && (
+            {isMounted && showWalletWarning && (
               <WalletWarning
                 handleClose={() => setShowWalletWarning(false)}
                 action={'get notifications'}

--- a/packages/frontend/src/pages/notifications.tsx
+++ b/packages/frontend/src/pages/notifications.tsx
@@ -68,7 +68,7 @@ export default function Notifications() {
                 {notificationsToShow.length > 0 ? (
                   notificationsToShow.map((n, i) => (
                     <div
-                      className="flex gap-4 justify-between outline-none rounded-2xl transition-all shadow-sm bg-white p-3 md:px-5 md:py-4 border border-gray-200 hover:border-gray-300 hover:cursor-pointer w-full"
+                      className="flex gap-4 justify-between items-center outline-none rounded-2xl transition-all shadow-sm bg-white p-3 md:px-5 md:py-4 border border-gray-200 hover:border-gray-300 hover:cursor-pointer w-full"
                       key={i}
                       onClick={() => {
                         setNotificationsAsRead(address as string, n.id);

--- a/packages/frontend/src/pages/notifications.tsx
+++ b/packages/frontend/src/pages/notifications.tsx
@@ -60,7 +60,7 @@ export default function Notifications() {
                     setSelectedFilter={setFilter}
                   />
                   <div
-                    className="flex gap-1 justify-end items-center"
+                    className="flex gap-1 justify-end items-center cursor-pointer"
                     onClick={() => setNotificationsAsRead({ address, markAll: true })}
                   >
                     <FontAwesomeIcon icon={faCheck} size={'xs'} />

--- a/packages/frontend/src/pages/notifications.tsx
+++ b/packages/frontend/src/pages/notifications.tsx
@@ -12,15 +12,14 @@ import { RefreshNotifications } from '@/components/notifications/RefreshNotifica
 import { WalletWarning } from '@/components/WalletWarning';
 import { NotificationsContextType } from '@/types/notifications';
 import { useIsMounted } from '@/hooks/useIsMounted';
+import { RetryError } from '@/components/global/RetryError';
 
 export default function Notifications() {
   const { address } = useAccount();
   const isMounted = useIsMounted();
   const { isValid, pushRoute, nymOptions } = useContext(UserContext) as UserContextType;
-  const { errorMsg, setError } = useError();
-  const { notifications, unread, isLoading, setNotificationsAsRead } = useContext(
-    NotificationsContext,
-  ) as NotificationsContextType;
+  const { notifications, unread, isLoading, setNotificationsAsRead, fetchNotifications, errorMsg } =
+    useContext(NotificationsContext) as NotificationsContextType;
 
   const [filter, setFilter] = useState('all');
   const [showWalletWarning, setShowWalletWarning] = useState(!address || !isValid);
@@ -51,6 +50,13 @@ export default function Notifications() {
             </div>
             {isLoading ? (
               <Spinner />
+            ) : errorMsg ? (
+              <RetryError
+                message={'Could not fetch notifications: '}
+                refetchHandler={() =>
+                  fetchNotifications({ address: address as string, nymOptions })
+                }
+              />
             ) : notificationsToShow ? (
               <>
                 <div className="flex justify-between items-center">

--- a/packages/frontend/src/pages/notifications.tsx
+++ b/packages/frontend/src/pages/notifications.tsx
@@ -70,7 +70,7 @@ export default function Notifications() {
                 {notificationsToShow.length > 0 ? (
                   notificationsToShow.map((n, i) => (
                     <div
-                      className="flex gap-4 justify-between items-center outline-none rounded-2xl transition-all shadow-sm bg-white p-3 md:px-5 md:py-4 border border-gray-200 hover:border-gray-300 hover:cursor-pointer w-full"
+                      className="flex gap-4 justify-between items-center outline-none rounded-2xl transition-all shadow-sm bg-white p-3 border border-gray-200 hover:border-gray-500 hover:cursor-pointer w-full"
                       key={i}
                       onClick={() => {
                         setNotificationsAsRead({ address, id: n.id });

--- a/packages/frontend/src/styles/globals.css
+++ b/packages/frontend/src/styles/globals.css
@@ -105,6 +105,21 @@
     white-space: nowrap;
   }
 
+  /* Spinner */
+  .loader {
+    animation: spinner 0.6s linear infinite;
+  }
+
+  @keyframes spinner {
+    0% {
+      transform: rotate(0deg);
+    }
+    100% {
+      transform: rotate(360deg);
+    }
+  }
+
+  /* Loading Ellipsis */
   .dot1 {
     animation: visibility 1s linear infinite;
   }

--- a/packages/frontend/types/notifications/index.ts
+++ b/packages/frontend/types/notifications/index.ts
@@ -29,9 +29,14 @@ export type ReplyNotification = BaseNotification & {
 
 export type Notification = UpvoteNotification | ReplyNotification;
 
+export type setReadArgs = {
+  address: string | undefined;
+  id?: string;
+  markAll?: boolean;
+};
 export type NotificationsContextType = {
   notifications: Notification[];
   unread: Notification[];
   isLoading: boolean;
-  setNotificationsAsRead: (address: string, id: string, markAll?: boolean) => void;
+  setNotificationsAsRead: (args: setReadArgs) => void;
 };

--- a/packages/frontend/types/notifications/index.ts
+++ b/packages/frontend/types/notifications/index.ts
@@ -49,4 +49,5 @@ export type NotificationsContextType = {
   setNotificationsAsRead: (args: setReadArgs) => void;
   fetchNotifications: (args: setFetchArgs) => Promise<void>;
   lastRefresh: string;
+  errorMsg: string;
 };

--- a/packages/frontend/types/notifications/index.ts
+++ b/packages/frontend/types/notifications/index.ts
@@ -1,3 +1,5 @@
+import { ClientName } from '../components';
+
 export enum NotificationType {
   Upvote,
   DirectReply,
@@ -34,9 +36,17 @@ export type setReadArgs = {
   id?: string;
   markAll?: boolean;
 };
+
+export type setFetchArgs = {
+  address: string;
+  nymOptions: ClientName[];
+};
+
 export type NotificationsContextType = {
   notifications: Notification[];
   unread: Notification[];
   isLoading: boolean;
   setNotificationsAsRead: (args: setReadArgs) => void;
+  fetchNotifications: (args: setFetchArgs) => Promise<void>;
+  lastRefresh: string;
 };


### PR DESCRIPTION
- Adds a global `NotificationsContext` to maintain notifications state for menu component and page
----
- Blue dot to indicate an unread notification, option to mark individual notification as read
<div style="display: flex">
<img height="200" alt="Screenshot 2023-06-08 at 4 00 31 PM" src="https://github.com/personaelabs/nym/assets/95446735/78d4e6fb-0a5b-4cac-b184-41383240a3a4">
<img height="150" alt="Screenshot 2023-06-08 at 4 00 51 PM" src="https://github.com/personaelabs/nym/assets/95446735/5c9124d3-fb2d-434c-823f-c243635f9d3d">
</div>

----
- Border outline on hover
<img width="418" alt="Screenshot 2023-06-08 at 4 03 33 PM" src="https://github.com/personaelabs/nym/assets/95446735/01b81af0-79a7-4a95-87c4-9ff799d8bb4c">

----
- Show last refresh
<img width="262" alt="Screenshot 2023-06-08 at 4 27 16 PM" src="https://github.com/personaelabs/nym/assets/95446735/6d5d2721-bba0-4210-8494-b1aabd9d1838">

----
- Error handling (added errors to the `NotificationsContext`, this isn't clean but it works for now)