### PR TITLE
Infinite scroll for home page

### DIFF
--- a/packages/frontend/public/api-doc.yml
+++ b/packages/frontend/public/api-doc.yml
@@ -24,6 +24,14 @@ paths:
           required: false
           schema:
             type: number
+        - name: sort
+          in: query
+          required: false
+          schema:
+            type: string
+            enum:
+              - timestamp
+              - upvotes
       responses:
         '200':
           description: OK

--- a/packages/frontend/src/components/Posts.tsx
+++ b/packages/frontend/src/components/Posts.tsx
@@ -56,10 +56,6 @@ export default function Posts(props: PostsProps) {
       },
     },
   );
-<<<<<<< HEAD
-=======
-
->>>>>>> 7dc9679 (chore: log)
   const [observedElement, setObservedElement] = useState<Element | null>();
 
   useEffect(() => {

--- a/packages/frontend/src/components/Posts.tsx
+++ b/packages/frontend/src/components/Posts.tsx
@@ -1,10 +1,10 @@
 import { PostPreview } from '@/components/post/PostPreview';
-import { useQuery } from '@tanstack/react-query';
+import { useInfiniteQuery } from '@tanstack/react-query';
 import axios from 'axios';
 import { IPostPreview } from '@/types/api';
 import Spinner from './global/Spinner';
 import { MainButton } from './MainButton';
-import { useContext, useMemo, useState } from 'react';
+import { useContext, useState } from 'react';
 import { NewPost } from './userInput/NewPost';
 import { Upvote } from './Upvote';
 import { RetryError } from './global/RetryError';
@@ -16,22 +16,21 @@ import { SortSelect } from './post/SortSelect';
 import { refetchAndScrollToPost } from '@/lib/client-utils';
 import { DiscardPostWarning } from './DiscardPostWarning';
 import { PostWithRepliesModal } from './post/PostWithRepliesModal';
+import { useEffect } from 'react';
 
-const getPosts = async () => (await axios.get<IPostPreview[]>('/api/v1/posts')).data;
+const PER_FETCH = 20;
+const getPosts = async ({ pageParam = 0 }: { pageParam?: number }, filter: String) => {
+  const data = (
+    await axios.get<IPostPreview[]>('/api/v1/posts', {
+      params: {
+        offset: pageParam,
+        limit: PER_FETCH,
+        sort: filter,
+      },
+    })
+  ).data;
 
-const sortPosts = (posts: IPostPreview[] | undefined, query: string) => {
-  return posts
-    ? posts.sort((a, b) => {
-        if (query === 'timestamp') {
-          const val1 = b[query] || new Date();
-          const val2 = a[query] || new Date();
-
-          return Number(new Date(val1)) - Number(new Date(val2));
-        } else if (query === 'upvotes') {
-          return Number(b[query].length) - Number(a[query].length);
-        } else return 0;
-      })
-    : posts;
+  return data;
 };
 
 interface PostsProps {
@@ -41,41 +40,49 @@ interface PostsProps {
 export default function Posts(props: PostsProps) {
   const { initOpenPostId } = props;
   const { errorMsg, setError } = useError();
-  const { isMobile, postInProg, pushRoute } = useContext(UserContext) as UserContextType;
   const [newPostOpen, setNewPostOpen] = useState(false);
   const [openPostId, setOpenPostId] = useState(initOpenPostId ? initOpenPostId : '');
   const [discardWarningOpen, setDiscardWarningOpen] = useState(false);
+  const { isMobile, pushRoute, postInProg } = useContext(UserContext) as UserContextType;
+  const [filter, setFilter] = useState<string>('timestamp');
 
-  const {
-    isLoading,
-    isError,
-    refetch,
-    data: posts,
-  } = useQuery<IPostPreview[]>({
-    queryKey: ['posts'],
-    queryFn: getPosts,
-    retry: 1,
-    enabled: true,
-    staleTime: 1000,
-    refetchIntervalInBackground: true,
-    refetchInterval: 30000, // 30 seconds
-    onError: (error) => {
-      setError(error);
+  const { isLoading, isFetchingNextPage, isError, refetch, fetchNextPage, data } = useInfiniteQuery(
+    {
+      queryKey: ['posts', { filter }],
+      queryFn: ({ pageParam }) => getPosts({ pageParam }, filter),
+      getNextPageParam: (_, pages) => pages.length * PER_FETCH,
+      onError: (error) => {
+        setError(error);
+      },
     },
-  });
+  );
+  const [observedElement, setObservedElement] = useState<Element | null>();
+
+  useEffect(() => {
+    const el = window.document.querySelector('#lastPost');
+    if (el && observedElement !== el) {
+      const options = {
+        root: null, // viewport,
+        rootMargin: '0px',
+        threshold: 0.1, // start fetching more as soon as 10% of the last post is visible
+      };
+
+      const observer = new IntersectionObserver((entries, observer) => {
+        entries.forEach((entry) => {
+          if (entry.isIntersecting) {
+            fetchNextPage();
+            observer.unobserve(entry.target);
+          }
+        });
+      }, options);
+      observer.observe(el as Element);
+      setObservedElement(el);
+    }
+  }, [data, fetchNextPage, observedElement]);
 
   const filterOptions: { [key: string]: string } = {
     timestamp: '⏳ Recent',
     upvotes: '🔥 Top',
-  };
-  const [filter, setFilter] = useState<string>('timestamp');
-  const sortedPosts = useMemo(() => sortPosts(posts, filter), [posts, filter]);
-  const handleOpenPost = (postId: string) => {
-    if (isMobile) pushRoute(`/posts/${postId}`);
-    else {
-      window.history.pushState(null, '', `/posts/${postId}`);
-      setOpenPostId(postId);
-    }
   };
 
   return (
@@ -107,7 +114,7 @@ export default function Posts(props: PostsProps) {
                 <>
                   <Spinner />
                 </>
-              ) : sortedPosts ? (
+              ) : data?.pages ? (
                 <>
                   <div className="flex justify-between">
                     {isMobile ? (
@@ -131,24 +138,45 @@ export default function Posts(props: PostsProps) {
                       />
                     </div>
                   </div>
-                  {sortedPosts.map((post) => (
-                    <div className="w-full flex gap-2 items-center" key={post.id}>
-                      <Upvote
-                        upvotes={post.upvotes}
-                        col={true}
-                        postId={post.id}
-                        onSuccess={refetch}
-                      >
-                        <p className="font-semibold text-gray-700">{post.upvotes.length}</p>
-                      </Upvote>
-                      <PostPreview
-                        {...post}
-                        userId={post.userId}
-                        handleOpenPost={() => handleOpenPost(post.id)}
-                        onSuccess={async () => await refetchAndScrollToPost(refetch)}
-                      />
-                    </div>
+                  {data.pages.map((page, i) => (
+                    <>
+                      {page.map((post, j) => (
+                        <div
+                          className="w-full flex gap-2"
+                          key={post.id}
+                          id={
+                            i === data.pages.length - 1 && j === page.length - 1 ? 'lastPost' : ''
+                          }
+                        >
+                          <Upvote
+                            upvotes={post.upvotes}
+                            col={true}
+                            postId={post.id}
+                            onSuccess={refetch}
+                          >
+                            <p className="font-semibold text-gray-700">{post.upvotes.length}</p>
+                          </Upvote>
+                          <PostPreview
+                            {...post}
+                            userId={post.userId}
+                            handleOpenPost={() => {
+                              if (isMobile) pushRoute(`/posts/${post.id}`);
+                              else {
+                                window.history.pushState(null, '', `/posts/${post.id}`);
+                                setOpenPostId(post.id);
+                              }
+                            }}
+                            onSuccess={async () => await refetchAndScrollToPost(refetch)}
+                          />
+                        </div>
+                      ))}
+                    </>
                   ))}
+                  {isFetchingNextPage && (
+                    <div className="flex justify-center my-4">
+                      <Spinner />
+                    </div>
+                  )}
                 </>
               ) : isError ? (
                 <RetryError

--- a/packages/frontend/src/components/Posts.tsx
+++ b/packages/frontend/src/components/Posts.tsx
@@ -4,7 +4,7 @@ import axios from 'axios';
 import { IPostPreview } from '@/types/api';
 import Spinner from './global/Spinner';
 import { MainButton } from './MainButton';
-import { useContext, useState } from 'react';
+import { Fragment, useContext, useState } from 'react';
 import { NewPost } from './userInput/NewPost';
 import { Upvote } from './Upvote';
 import { RetryError } from './global/RetryError';
@@ -139,7 +139,7 @@ export default function Posts(props: PostsProps) {
               ) : data?.pages ? (
                 <>
                   {data.pages.map((page, i) => (
-                    <>
+                    <Fragment key={i}>
                       {page.map((post, j) => (
                         <div
                           className="w-full flex gap-2"
@@ -170,7 +170,7 @@ export default function Posts(props: PostsProps) {
                           />
                         </div>
                       ))}
-                    </>
+                    </Fragment>
                   ))}
                   {isFetchingNextPage && (
                     <div className="flex justify-center my-4">

--- a/packages/frontend/src/components/Posts.tsx
+++ b/packages/frontend/src/components/Posts.tsx
@@ -110,34 +110,34 @@ export default function Posts(props: PostsProps) {
         <div className="w-full bg-gray-50 flex flex-col justify-center items-center">
           <div className="bg-gray-50 min-h-screen w-full">
             <div className="flex flex-col gap-8 max-w-3xl mx-auto py-5 md:py-10 px-4 md:px-0">
+              <div className="flex justify-between">
+                {isMobile ? (
+                  <SortSelect
+                    options={filterOptions}
+                    selectedQuery={filter}
+                    setSelectedQuery={setFilter}
+                  />
+                ) : (
+                  <Filters
+                    filters={filterOptions}
+                    selectedFilter={filter}
+                    setSelectedFilter={setFilter}
+                  />
+                )}
+                <div className="grow-0">
+                  <MainButton
+                    color="#0E76FD"
+                    message="Start Discussion"
+                    handler={() => setNewPostOpen(true)}
+                  />
+                </div>
+              </div>
               {isLoading ? (
                 <>
                   <Spinner />
                 </>
               ) : data?.pages ? (
                 <>
-                  <div className="flex justify-between">
-                    {isMobile ? (
-                      <SortSelect
-                        options={filterOptions}
-                        selectedQuery={filter}
-                        setSelectedQuery={setFilter}
-                      />
-                    ) : (
-                      <Filters
-                        filters={filterOptions}
-                        selectedFilter={filter}
-                        setSelectedFilter={setFilter}
-                      />
-                    )}
-                    <div className="grow-0">
-                      <MainButton
-                        color="#0E76FD"
-                        message="Start Discussion"
-                        handler={() => setNewPostOpen(true)}
-                      />
-                    </div>
-                  </div>
                   {data.pages.map((page, i) => (
                     <>
                       {page.map((post, j) => (

--- a/packages/frontend/src/components/Posts.tsx
+++ b/packages/frontend/src/components/Posts.tsx
@@ -56,6 +56,10 @@ export default function Posts(props: PostsProps) {
       },
     },
   );
+<<<<<<< HEAD
+=======
+
+>>>>>>> 7dc9679 (chore: log)
   const [observedElement, setObservedElement] = useState<Element | null>();
 
   useEffect(() => {

--- a/packages/frontend/src/pages/api/v1/posts.ts
+++ b/packages/frontend/src/pages/api/v1/posts.ts
@@ -45,8 +45,9 @@ const verifyRoot = async (root: string): Promise<boolean> =>
 const handleGetPosts = async (req: NextApiRequest, res: NextApiResponse<IPostPreview[]>) => {
   const skip = req.query.offset ? parseInt(req.query.offset as string) : 0;
   const take = req.query.limit ? parseInt(req.query.limit as string) : 10;
+  const sort = req.query.sort ? (req.query.sort as string) : 'timestamp'; // 'upvotes' or 'timestamp'. Default is 'timestamp'.
 
-  const posts = await selectAndCleanPosts(undefined, skip, take);
+  const posts = await selectAndCleanPosts(undefined, skip, take, sort);
   res.send(posts);
 };
 

--- a/packages/frontend/src/pages/api/v1/utils.ts
+++ b/packages/frontend/src/pages/api/v1/utils.ts
@@ -98,7 +98,6 @@ export const selectAndCleanPosts = async (
   const isNym = userId && !isAddress(userId);
   // Determines whether we are searching for a user's posts or all root posts.
   const where = userId ? { userId: isNym ? userId : userId.toLowerCase() } : { rootId: null };
-  console.log(`sort = `, sort);
   const postsRaw = await prisma.post.findMany({
     select: postPreviewSelect,
     where,

--- a/packages/frontend/src/pages/api/v1/utils.ts
+++ b/packages/frontend/src/pages/api/v1/utils.ts
@@ -89,18 +89,29 @@ export const getRootFromParent = async (parentId: string): Promise<string | null
   return rootId;
 };
 
-export const selectAndCleanPosts = async (userId?: string, skip?: number, take?: number) => {
+export const selectAndCleanPosts = async (
+  userId?: string,
+  skip?: number,
+  take?: number,
+  sort?: string,
+) => {
   const isNym = userId && !isAddress(userId);
   // Determines whether we are searching for a user's posts or all root posts.
   const where = userId ? { userId: isNym ? userId : userId.toLowerCase() } : { rootId: null };
+
   const postsRaw = await prisma.post.findMany({
     select: postPreviewSelect,
     where,
     skip,
     take,
-    orderBy: {
-      timestamp: 'desc',
-    },
+    orderBy:
+      sort === 'upvotes'
+        ? {
+            upvotes: {
+              _count: 'desc',
+            },
+          }
+        : { timestamp: 'desc' },
   });
 
   return postsRaw;

--- a/packages/frontend/src/pages/api/v1/utils.ts
+++ b/packages/frontend/src/pages/api/v1/utils.ts
@@ -98,7 +98,7 @@ export const selectAndCleanPosts = async (
   const isNym = userId && !isAddress(userId);
   // Determines whether we are searching for a user's posts or all root posts.
   const where = userId ? { userId: isNym ? userId : userId.toLowerCase() } : { rootId: null };
-
+  console.log(`sort = `, sort);
   const postsRaw = await prisma.post.findMany({
     select: postPreviewSelect,
     where,
@@ -106,11 +106,11 @@ export const selectAndCleanPosts = async (
     take,
     orderBy:
       sort === 'upvotes'
-        ? {
-            upvotes: {
-              _count: 'desc',
-            },
-          }
+        ? [
+            { descendants: { _count: 'desc' } },
+            { root: { descendants: { _count: 'desc' } } },
+            { upvotes: { _count: 'desc' } },
+          ]
         : { timestamp: 'desc' },
   });
 


### PR DESCRIPTION
Infinite scroll of posts for the home page.

- Switch useQuery to [useInfiniteQuery](https://tanstack.com/query/v4/docs/react/guides/infinite-queries).
- Switch to server-side sorting.
- Use the [Intersection Observer API](https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API) to determine the timing to feth the next chunk. More precisely, when the last element of the currently fetched chunk comes into the viewport (i.e. user's view), we fetch the next chunk. We can make the timing to fetch the next chunk to be earlier if necessary. But when we make it too early the scrolling experience becomes a little weird (the scroll bar bounces back up mid-scroll).


Notes
- The all-users and (single) user pages don't do paginations; they fetch all data simultaneously. It might be valuable to switch these pages to infinite scroll (before or after launch) as well if the infinite scroll for the home page works well.

