### PR TITLE
Fix: body text URL hyperlinks

### DIFF
--- a/packages/frontend/src/components/proposals/BodyWithPropLink.tsx
+++ b/packages/frontend/src/components/proposals/BodyWithPropLink.tsx
@@ -1,4 +1,4 @@
-import { splitStringByExp } from '@/lib/client-utils';
+import { splitStringByExps } from '@/lib/client-utils';
 import { PropsContext } from '@/pages/_app';
 import { PropsContextType } from '@/types/components';
 import { useContext } from 'react';
@@ -6,19 +6,22 @@ import { PropLink } from './PropLink';
 
 export const BodyWithPropLink = ({ body }: { body: string }) => {
   const { proposals } = useContext(PropsContext) as PropsContextType;
-  const regex = /#(\d+)/g;
-  const strings = splitStringByExp(body, regex);
+  const propRegex = /#(\d+)/g;
+  const urlRegex = /(https?:\/\/[^\s]+)/g;
+  const strings = splitStringByExps(body, [propRegex, urlRegex]);
 
   const bodyWithPropLink = strings.map((s) => {
-    regex.lastIndex = 0;
-    if (regex.test(s)) {
+    propRegex.lastIndex = 0;
+    if (propRegex.test(s)) {
       const proposal = proposals?.find((p) => p.id === s.substring(1));
-      return proposal ? (
-        <PropLink string={s} proposal={proposal} key={s} />
-      ) : (
-        <span key={s}>{s}</span>
+      return proposal ? <PropLink string={s} proposal={proposal} /> : <span>{s}</span>;
+    } else if (urlRegex.test(s)) {
+      return (
+        <a className="underline cursor-pointer break-all" href={s} key={s} target="_blank">
+          {s}
+        </a>
       );
-    } else return <span key={s}>{s}</span>;
+    } else return <span>{s}</span>;
   });
 
   return <div className="inline-block whitespace-pre-wrap">{bodyWithPropLink}</div>;

--- a/packages/frontend/src/components/proposals/BodyWithPropLink.tsx
+++ b/packages/frontend/src/components/proposals/BodyWithPropLink.tsx
@@ -12,6 +12,7 @@ export const BodyWithPropLink = ({ body }: { body: string }) => {
 
   const bodyWithPropLink = strings.map((s) => {
     propRegex.lastIndex = 0;
+    urlRegex.lastIndex = 0;
     if (propRegex.test(s)) {
       const proposal = proposals?.find((p) => p.id === s.substring(1));
       return proposal ? <PropLink string={s} proposal={proposal} /> : <span>{s}</span>;

--- a/packages/frontend/src/lib/client-utils.ts
+++ b/packages/frontend/src/lib/client-utils.ts
@@ -94,22 +94,23 @@ export const refetchAndScrollToPost = async (refetch: () => Promise<any>, postId
   }, 1000);
 };
 
-export const splitStringByExp = (text: string, search: RegExp): string[] => {
+export const splitStringByExps = (text: string, searchArray: RegExp[]): string[] => {
   const matches = [];
   let lastIndex = 0;
-  let match;
+  for (const search of searchArray) {
+    let match;
+    while ((match = search.exec(text)) !== null) {
+      const matchIndex = match.index;
+      const matchString = match[0];
 
-  while ((match = search.exec(text)) !== null) {
-    const matchIndex = match.index;
-    const matchString = match[0];
+      if (lastIndex !== matchIndex) {
+        const substring = text.substring(lastIndex, matchIndex);
+        matches.push(substring);
+      }
 
-    if (lastIndex !== matchIndex) {
-      const substring = text.substring(lastIndex, matchIndex);
-      matches.push(substring);
+      matches.push(matchString);
+      lastIndex = search.lastIndex;
     }
-
-    matches.push(matchString);
-    lastIndex = search.lastIndex;
   }
 
   if (lastIndex < text.length) {


### PR DESCRIPTION
Closes #246 
When we parse the body text to style proposal hyperlinks (see #195), we ignore URL hyperlinks, rendering all non-prop-link text in a `<span>` element. This PR adds a `urlRegex` to the body text parsing function and converts all URL hyperlinks to a styled `<a>` element.